### PR TITLE
fix(e2e): patch II bundle for DUMMY_AUTH + headless Chrome CI fixes

### DIFF
--- a/.github/workflows/shared-build.yml
+++ b/.github/workflows/shared-build.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Download PocketIC binary
         if: steps.cache-pocket-ic.outputs.cache-hit != 'true'
         run: |
+          mkdir -p ~/.local/bin
           curl -fsSL https://github.com/dfinity/pocketic/releases/download/12.0.0/pocket-ic-x86_64-linux.gz \
             | gzip -d > ~/.local/bin/pocket-ic
           chmod +x ~/.local/bin/pocket-ic

--- a/.github/workflows/shared-build.yml
+++ b/.github/workflows/shared-build.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       # Prefer IPv4 DNS results in Node (affects dev servers, tooling, etc.)
       NODE_OPTIONS: --dns-result-order=ipv4first
+      POCKET_IC_BIN: /home/runner/.local/bin/pocket-ic
 
     steps:
       - name: Checkout code
@@ -45,13 +46,19 @@ jobs:
           restore-keys: |
             rust-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}-
 
-      - name: Cache PocketIC binaries
+      - name: Cache PocketIC binary
+        id: cache-pocket-ic
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.local/share/icp-cli/pkg/
-            ~/.cache/dfinity/
-          key: pocket-ic-${{ runner.os }}-v1
+          path: ~/.local/bin/pocket-ic
+          key: pocket-ic-${{ runner.os }}-12.0.0
+
+      - name: Download PocketIC binary
+        if: steps.cache-pocket-ic.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL https://github.com/dfinity/pocketic/releases/download/12.0.0/pocket-ic-x86_64-linux.gz \
+            | gzip -d > ~/.local/bin/pocket-ic
+          chmod +x ~/.local/bin/pocket-ic
 
       - name: Install icp-cli
         run: npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm

--- a/.github/workflows/shared-build.yml
+++ b/.github/workflows/shared-build.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Download PocketIC binary
         if: steps.cache-pocket-ic.outputs.cache-hit != 'true'
         run: |
-          mkdir -p ~/.local/bin
           curl -fsSL https://github.com/dfinity/pocketic/releases/download/12.0.0/pocket-ic-x86_64-linux.gz \
             | gzip -d > ~/.local/bin/pocket-ic
           chmod +x ~/.local/bin/pocket-ic

--- a/.github/workflows/shared-build.yml
+++ b/.github/workflows/shared-build.yml
@@ -15,7 +15,6 @@ jobs:
     env:
       # Prefer IPv4 DNS results in Node (affects dev servers, tooling, etc.)
       NODE_OPTIONS: --dns-result-order=ipv4first
-      POCKET_IC_BIN: /home/runner/.local/bin/pocket-ic
 
     steps:
       - name: Checkout code
@@ -46,19 +45,13 @@ jobs:
           restore-keys: |
             rust-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}-
 
-      - name: Cache PocketIC binary
-        id: cache-pocket-ic
+      - name: Cache PocketIC binaries
         uses: actions/cache@v4
         with:
-          path: ~/.local/bin/pocket-ic
-          key: pocket-ic-${{ runner.os }}-12.0.0
-
-      - name: Download PocketIC binary
-        if: steps.cache-pocket-ic.outputs.cache-hit != 'true'
-        run: |
-          curl -fsSL https://github.com/dfinity/pocketic/releases/download/12.0.0/pocket-ic-x86_64-linux.gz \
-            | gzip -d > ~/.local/bin/pocket-ic
-          chmod +x ~/.local/bin/pocket-ic
+          path: |
+            ~/.local/share/icp-cli/pkg/
+            ~/.cache/dfinity/
+          key: pocket-ic-${{ runner.os }}-v1
 
       - name: Install icp-cli
         run: npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm

--- a/.github/workflows/shared-build.yml
+++ b/.github/workflows/shared-build.yml
@@ -56,5 +56,5 @@ jobs:
           getent hosts localhost || true
 
       - name: Build, validate and run tests (E2E)
-        # TODO(derive-ii-principal): remove --skip-checks --skip-acceptance before merging
-        run: ./validate-and-test-all.sh --skip-checks --skip-acceptance ${{ inputs.include-vite-e2e && '--include-vite-e2e' || '' }}
+        # TODO(derive-ii-principal): remove --skip-acceptance before merging
+        run: ./validate-and-test-all.sh --skip-acceptance ${{ inputs.include-vite-e2e && '--include-vite-e2e' || '' }}

--- a/.github/workflows/shared-build.yml
+++ b/.github/workflows/shared-build.yml
@@ -56,4 +56,5 @@ jobs:
           getent hosts localhost || true
 
       - name: Build, validate and run tests (E2E)
-        run: ./validate-and-test-all.sh ${{ inputs.include-vite-e2e && '--include-vite-e2e' || '' }}
+        # TODO(derive-ii-principal): remove --skip-checks --skip-acceptance before merging
+        run: ./validate-and-test-all.sh --skip-checks --skip-acceptance ${{ inputs.include-vite-e2e && '--include-vite-e2e' || '' }}

--- a/.github/workflows/shared-build.yml
+++ b/.github/workflows/shared-build.yml
@@ -56,5 +56,4 @@ jobs:
           getent hosts localhost || true
 
       - name: Build, validate and run tests (E2E)
-        # TODO(derive-ii-principal): remove --skip-acceptance before merging
-        run: ./validate-and-test-all.sh --skip-acceptance ${{ inputs.include-vite-e2e && '--include-vite-e2e' || '' }}
+        run: ./validate-and-test-all.sh ${{ inputs.include-vite-e2e && '--include-vite-e2e' || '' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,29 @@ Every canister serves the dashboard at `/canister-dashboard` with HTTP certifica
 
 The `demos` canister provides time-limited trial access via access codes (XXXX-XXXX-XXXX). Redemption: atomically claim code → take canister from pool → install wasm → II auth (same derivationOrigin pattern) → set principal → start trial timer. On expiry, wasm is uninstalled and canister returned to pool. See `docs/demos-feature.md`.
 
+## ⚠️ Internet Identity in Local Dev: II v2 DUMMY_AUTH
+
+**IMPORTANT — Read this before working on anything II-related locally.**
+
+The II canister bundled with `icp-cli` (`ii: true` in `icp.yaml`) is **Internet Identity v2 in dev/dummy mode**. It behaves completely differently from production II:
+
+- **No WebAuthn hardware required.** The build flag `pP=!0` (DUMMY_AUTH=true) forces `let Al=M0` — the auth class is always `M0` (dummy), which generates credentials from a fixed seed (all zeros) without calling any WebAuthn APIs.
+- **`M0.createNew()` / `M0.useExisting()`** return `Promise.resolve(new M0(r))` instantly. No `credentials.create()`, no `credentials.get()`, no platform authenticator needed.
+- **Credential ID is always 32 zero bytes** (deterministic, seed=0). First run on a fresh canister: `lookup_device_key(zeros)` → not found → "Create new identity" flow. Subsequent runs → found → "Continue" directly.
+- **`dapp derive-ii-principal`** works out of the box on macOS: `dapp derive-ii-principal https://test.com` returns a principal in ~5s.
+
+**Do NOT add CDP virtual authenticators, attestation patches, or CBOR hacks for local II dev.** These are only relevant for production II or non-DUMMY_AUTH builds.
+
+### Headless Linux CI patches (only for CI, not for logic changes)
+
+Headless Linux Chrome still needs these patches in `derive-principal.mjs` `addInitScript`:
+1. `isUserVerifyingPlatformAuthenticatorAvailable = () => Promise.resolve(true)` — CI's newer II build gates the "Create new identity" button on this returning true; headless Linux returns false by default.
+2. `credentials.get()` intercept for empty `allowCredentials` → reject with `NotAllowedError` — the `/authorize` page calls this on mount for passkey autofill; on headless Linux it throws `NotSupportedError` and blocks the UI.
+3. DNS proxy: `context.route()` + Node.js `http.request()` to `127.0.0.1` for `*.localhost` — Linux headless Chrome doesn't resolve `*.localhost` subdomains.
+4. Gzip decompression: decompress in Node.js before `route.fulfill()` and strip hop-by-hop headers.
+
+These are CI environment workarounds — they don't change the II auth logic (still DUMMY_AUTH).
+
 ## Commands
 
 Uses `icp-cli` (`icp` command) — **not dfx**. Config: `icp.yaml`. Networks: `local` (PocketIC on port 8080), `ic` (mainnet).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,7 +1441,6 @@ dependencies = [
 name = "my-canister-frontend"
 version = "0.3.0"
 dependencies = [
- "candid",
  "flate2",
  "ic-asset-certification",
  "ic-cdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,6 +1441,7 @@ dependencies = [
 name = "my-canister-frontend"
 version = "0.3.0"
 dependencies = [
+ "candid",
  "flate2",
  "ic-asset-certification",
  "ic-cdk",

--- a/docs/ai-backend-reference.md
+++ b/docs/ai-backend-reference.md
@@ -125,14 +125,13 @@ fn init() {
 
 #### `setup_frontend_with_config(assets_dir: &Dir<'static>, config: &FrontendConfig) -> Result<(), String>`
 
-Initialize with custom configuration (extra file types, larger size limit).
+Initialize with custom configuration (extra file types).
 
 ```rust
 use my_canister_frontend::{setup_frontend_with_config, FrontendConfig};
 
 let config = FrontendConfig {
     extra_allowed_extensions: vec!["webmanifest".to_string(), "glb".to_string()],
-    max_file_size: 5 * 1024 * 1024, // 5 MB
 };
 setup_frontend_with_config(&FRONTEND_DIR, &config).expect("Failed to setup frontend");
 ```
@@ -167,8 +166,6 @@ with_asset_router_mut(|router| {
 pub struct FrontendConfig {
     /// Additional file extensions beyond the defaults (e.g., "webmanifest", "glb")
     pub extra_allowed_extensions: Vec<String>,
-    /// Maximum file size in bytes (default: 2 MB = 2_097_152)
-    pub max_file_size: usize,
 }
 ```
 

--- a/docs/derive-ii-principal-ci-lessons.md
+++ b/docs/derive-ii-principal-ci-lessons.md
@@ -152,3 +152,169 @@ the existing session ("Continue" appears directly).
 | `packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs` | CLI: all 4 patches above |
 | `tests/fixtures.ts` | E2E tests: same 4 patches as a Playwright test fixture |
 | `tests/ii-helpers.ts` | Simplified II popup flow (CWP → "Create new identity" directly) |
+
+---
+
+## E2E launcher tests: `derivationOrigin` flow (second II popup)
+
+The icp-dapp-launcher tests have a second II popup triggered by "Connect II to Dapp".
+This popup uses `derivationOrigin` so that II derives the principal the user will have
+when visiting their canister directly (the ownership handoff mechanism).
+
+### Additional patch 5 — `u7()` DUMMY_AUTH boolean check (second popup only)
+
+**Problem**: The second II popup (triggered by "Connect II to Dapp") starts with
+`$isAuthenticatedStore = false` — it's a fresh window with no existing session.
+This means the z() "Continue" handler in `hq()` calls `U.authenticate(i().selected)`
+instead of short-circuiting. `e0.authenticate()` sees `"passkey" in t.authMethod`
+→ calls `u7()`.
+
+`u7()` contains a **boolean assignment** form of the DUMMY_AUTH check:
+
+```javascript
+const s=Vr.dummy_auth[0]?.[0]!==void 0;let o;const a=s?ga.useExisting():ps.useExisting(
+```
+
+The `replaceAll('Vr.dummy_auth[0]?.[0]!==void 0?', 'true?')` patch only covers the
+**ternary** form (5 occurrences, all have a trailing `?`). The boolean assignment in
+`u7()` has no trailing `?`, so `replaceAll` silently skips it. `s` stays `false`,
+`ps.useExisting()` is called (real WebAuthn), which calls `credentials.get()`,
+which our `addInitScript` patch rejects with `NotAllowedError`. The error is silently
+caught by z(), shows a toast, `authorize-client-success` is never sent, `AuthClient.login()`
+hangs forever, and the busy overlay never clears.
+
+Full call chain in the second popup:
+```
+z() → U.authenticate() → e0.authenticate() → u7() → ps.useExisting()
+  → credentials.get() → NotAllowedError (our addInitScript)
+  → z() catch → toast only → authorize-client-success never sent
+  → AuthClient.login() hangs → finally/stopBusy never runs → busy overlay persists
+```
+
+**Fix**: Add a targeted `replace()` after the `replaceAll()` to cover the boolean form:
+
+```javascript
+src = src.replaceAll('Vr.dummy_auth[0]?.[0]!==void 0?', 'true?');
+src = src.replace(
+  'Vr.dummy_auth[0]?.[0]!==void 0;let o;const a=s?ga.useExisting():ps.useExisting(',
+  'true;let o;const a=s?ga.useExisting():ps.useExisting('
+);
+```
+
+**Why the first popup doesn't hit this**: After `handleIIPopup` creates a new identity,
+`$isAuthenticatedStore` becomes `true`. On second mount (the "Continue" flow),
+`o() === true` causes `hq()` to skip `U.authenticate()` entirely and call
+`prepare_account_delegation` directly. So u7() is never reached in the first popup's
+second-phase click.
+
+### Additional patch 6 — `Unverified origin` in II's `Rm()` validator
+
+**Problem**: II v2's `handleRequest` calls `Rm({requestOrigin, derivationOrigin})`
+before showing the auth UI. `Rm()` fetches:
+
+```
+http://localhost:8080/.well-known/ii-alternative-origins?canisterId=<new-canister-id>
+```
+
+(URL built by `nO()` which uses `window.location.hostname` = `*.localhost`.)
+
+The fetch option is `{redirect:"error"}`. PocketIC's HTTP gateway redirects
+`localhost:8080?canisterId=` requests, which causes the fetch to throw. The `catch`
+block returns `{result:"invalid"}` → `throw new Error("Unverified origin")` → the
+auth UI never renders.
+
+**Key insight**: The alternative origins ARE correctly set on the canister by
+`addInstallerOrigin()` before the popup opens. The problem is purely in how II
+fetches them (wrong URL format for our PocketIC setup). Origin security doesn't
+apply in DUMMY_AUTH mode anyway.
+
+**Fix**: Add a third bundle patch after the DUMMY_AUTH and seed patches:
+
+```javascript
+// Bypass derivationOrigin origin-check: Rm() fetch fails in PocketIC local env
+src = src.replace(
+  '.result==="invalid")throw new Error("Unverified origin")',
+  '.result==="__bypassed__")throw new Error("Unverified origin")'
+);
+```
+
+This makes the condition permanently false (Rm() never returns `"__bypassed__"`),
+so `throw new Error("Unverified origin")` never fires. `tp.set({authRequest})` is
+then called normally and the auth UI renders.
+
+**How to find the pattern**: `curl -s http://rdmx6-jaaaa-aaaaa-aaadq-cai.localhost:8080/_app/immutable/entry/start.*.js | gunzip | grep -o '.\{120\}Unverified origin.\{120\}'`
+
+### Additional patch 7 — `fetchRootKey` cross-origin failure
+
+**Problem**: The dapp store page initialises a `WasmRegistryApi` agent with
+`host: 'http://localhost:8080'` (baked in at build time when `PROD=false`).
+`fetchRootKey()` calls `window.fetch('http://localhost:8080/api/v2/status')`.
+This is cross-origin from `*.localhost:8080` and either fails CORS or hits IPv6
+vs IPv4 (`::1` vs `127.0.0.1`).
+
+**Fix**: Extend the `context.route()` filter to also intercept plain `localhost`:
+
+```typescript
+// Before: only *.localhost
+(url) => url.hostname.endsWith('.localhost')
+// After: also plain localhost
+(url) => url.hostname === 'localhost' || url.hostname.endsWith('.localhost')
+```
+
+Also add `MAP localhost 127.0.0.1` to `--host-resolver-rules` in `playwright.config.ts`
+as belt-and-suspenders for cases where Chrome bypasses the route handler.
+
+### Additional fix — popup race condition + missing busy-wait (test-level, not bundle)
+
+**Problem 1 (race)**: Both tests registered `page.waitForEvent('popup')` AFTER
+clicking "Connect II to Dapp". If the `AuthClient.login()` → `window.open()` call
+happens synchronously or very quickly, the popup event fires before the listener is
+registered and Playwright misses it. `handleIIPopup` then runs on the wrong popup
+(or the promise hangs), and the real II popup never gets its "Continue" clicked.
+
+**Fix**: Always register the popup listener BEFORE the click:
+
+```typescript
+// WRONG — race condition:
+await page.click('Connect II to Dapp');
+const popupPromise = page.waitForEvent('popup');
+
+// CORRECT:
+const popupPromise = page.waitForEvent('popup');
+await page.click('Connect II to Dapp');
+```
+
+**Problem 2 (missing busy-wait)**: After `handleIIPopup` returns, the launcher
+still performs canister calls (`setIIPrincipal`, `setControllers` or `finalizeDemo`).
+These run inside a `busyStore.startBusy('connect-ii')` scope. The busy overlay
+(`div[data-tid="busy"]`) intercepts all pointer events until `stopBusy` fires in the
+`finally` block. Without an explicit wait, `page.click('My Dapps')` retries for the
+entire remaining test timeout and fails.
+
+**Fix**: Wait for the busy overlay to hide before navigating:
+
+```typescript
+await handleIIPopup(iiPopup);
+await page.locator('[data-tid="busy"]').waitFor({ state: 'hidden', timeout: 90_000 });
+await page.getByRole('menuitem', { name: 'My Dapps' }).click();
+```
+
+**Why `AuthClient.login()` hangs without the race fix**: `@icp-sdk/auth/client`'s
+`AuthClient.login()` opens a popup and awaits `{kind:"authorize-client-success"}`
+via `window.addEventListener("message", ...)`. If the II popup was missed (wrong
+popup captured), `authorize-client-success` is never received, `remoteAuth()` never
+resolves, and the `finally { stopBusy() }` block never runs → busy overlay persists
+for the full 120s test timeout.
+
+---
+
+## Files changed (complete list)
+
+| File | Purpose |
+|------|---------|
+| `packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs` | CLI: DUMMY_AUTH + seed + DNS proxy patches |
+| `tests/fixtures.ts` | E2E tests: DUMMY_AUTH (ternary + u7 boolean) + seed + Unverified-origin + NoSuchOrigin + fetchRootKey proxy patches |
+| `tests/ii-helpers.ts` | II popup flow handler (CWP → Create new identity, or Continue directly) |
+| `playwright.config.ts` | `--host-resolver-rules` for both `*.localhost` and `localhost` |
+| `tests/icp-dapp-launcher/install-dapp.spec.ts` | Race fix + busy-wait after second II popup |
+| `tests/icp-dapp-launcher/install-demo.spec.ts` | Race fix + busy-wait after second II popup |

--- a/docs/derive-ii-principal-ci-lessons.md
+++ b/docs/derive-ii-principal-ci-lessons.md
@@ -1,0 +1,154 @@
+# Lessons Learned: `dapp derive-ii-principal` on Headless Linux CI
+
+## What the command does
+
+`dapp derive-ii-principal <origin>` opens a headless Playwright/Chromium browser,
+navigates to a page at the canister origin, triggers an II login popup, clicks
+through the II UI, and writes the derived principal to stdout. Called 4× in
+`04-deploy.sh` to set controllers on freshly created canisters.
+
+---
+
+## Root cause: icp-cli 0.2.1 config bug (not an II update)
+
+`icp-cli` bundles a dev build of Internet Identity that has **DUMMY_AUTH compiled
+in** (`pP=!0` build flag). In DUMMY_AUTH mode, the II auth class is always `ga`
+(a pure software Ed25519 key), which never calls any WebAuthn APIs. No platform
+authenticator is needed.
+
+However, `icp-cli` 0.2.1 deploys this canister with a buggy config:
+
+```
+dummy_auth = opt null          ← icp-cli 0.2.1 (WRONG: Some(None))
+dummy_auth = opt opt {...}     ← correct would be Some(Some({...}))
+```
+
+The II bundle checks: `Vr.dummy_auth[0]?.[0] !== void 0`
+
+- With `opt null` (Some(None)): `Vr.dummy_auth[0]` is `None`/`undefined` → check is `false` → **real WebAuthn path** (`ps` class, calls `credentials.create()`)
+- With `opt opt {...}` (Some(Some({...}))): check is `true` → **DUMMY_AUTH path** (`ga` class, pure software)
+
+On headless Linux, `credentials.create()` throws `NotSupportedError`. That's the
+entire failure. The bundle has DUMMY_AUTH capability; the config bug disables it.
+
+**This is not an II version change.** The same bug exists in all icp-cli 0.2.x
+releases. The CI used a slightly newer II build than local (`start.xYiFCL5p.js`
+vs `start.CggNA08c.js`), but both have the same config bug.
+
+---
+
+## The fix
+
+Patch the II JS bundle in the `context.route()` proxy handler to force the
+DUMMY_AUTH check to `true`:
+
+```javascript
+// In context.route() after decompressing the response body:
+const p = url.pathname;
+if (p.includes('/_app/immutable/entry/start') && p.endsWith('.js')) {
+  let src = body.toString('utf8');
+  // Force DUMMY_AUTH — bypasses all real WebAuthn, uses pure Ed25519 software key
+  src = src.replaceAll('Vr.dummy_auth[0]?.[0]!==void 0?', 'true?');
+  // Unique seed per invocation so each call registers a fresh credential;
+  // avoids "credential already registered" conflicts across the 4 CLI calls
+  src = src.replace('return BigInt(0)}', 'return BigInt(Math.floor(Math.random()*Number.MAX_SAFE_INTEGER))}');
+  body = Buffer.from(src, 'utf8');
+}
+```
+
+With DUMMY_AUTH active, no `credentials.create()` or `credentials.get()` is ever
+called. The entire CDP virtual authenticator approach (which dominated earlier
+debugging sessions) was unnecessary.
+
+---
+
+## Remaining CI patches (environment workarounds only)
+
+These fix headless Linux environment gaps. They do not change II auth logic.
+
+### 1 — DNS: `*.localhost` doesn't resolve
+
+**Problem**: Chromium's sandboxed network service on Linux doesn't resolve
+`*.localhost` subdomains. PocketIC canisters live at `<id>.localhost:8080`.
+
+**Fix**: `context.route()` intercepts all `*.localhost` requests and proxies them
+via Node.js `http.request()` to `127.0.0.1`, preserving the `Host` header so
+PocketIC routes to the right canister.
+
+**Why not `--host-resolver-rules` alone?** The Chrome flag works for browser
+requests but not for Playwright's `route.fetch()`, which runs in Node.js and uses
+OS DNS. Since we need to patch the bundle anyway, the Node.js proxy handles both.
+
+### 2 — Gzip: `route.fulfill()` doesn't decompress
+
+**Problem**: PocketIC serves gzip/brotli assets. `route.fulfill()` passes the
+raw bytes to Chrome with hop-by-hop headers stripped; Chrome tries to parse
+compressed bytes as JS and throws "Invalid or unexpected token".
+
+**Fix**: Decompress in Node.js (`zlib.gunzipSync`, `brotliDecompressSync`) before
+calling `route.fulfill()`, and strip all hop-by-hop headers.
+
+### 3 — `isUserVerifyingPlatformAuthenticatorAvailable()` returns false
+
+**Problem**: Newer II builds (icp-cli 0.2.1's `start.xYiFCL5p.js`) gate the
+"Create new identity" button on this returning `true`. Headless Linux returns
+`false`, leaving the button disabled even after DUMMY_AUTH is forced.
+
+**Fix**: `addInitScript` overrides the API to return `Promise.resolve(true)` before
+any page JS runs. Must be synchronous (before II's SvelteKit boot code), which is
+why `addInitScript` is used rather than a post-load patch.
+
+### 4 — `credentials.get()` throws `NotSupportedError`, freezes UI
+
+**Problem**: The II `/authorize` page calls `credentials.get({allowCredentials: []})`
+on mount for passkey autofill. On headless Linux this throws `NotSupportedError`,
+which propagates up and blocks the UI from rendering buttons.
+
+**Fix**: `addInitScript` replaces `navigator.credentials.get` with a function that
+rejects with `NotAllowedError`. II treats this as "no passkeys found" and renders
+the UI normally.
+
+---
+
+## The dead end: CDP virtual authenticators
+
+Earlier debugging sessions spent significant time building a CDP virtual
+authenticator approach: intercept `credentials.create()`, synthesise a valid
+WebAuthn attestation object with correct CBOR, DER signatures, authData layout,
+etc. (9 layers of patches). **This was entirely unnecessary.**
+
+The clue that should have ended this earlier: `icp-cli` ships a *dev* II build.
+Dev builds never need real WebAuthn. If you're patching CBOR decoders and
+generating synthetic ECDSA signatures, you're on the wrong path.
+
+**Rule**: Before adding any WebAuthn workaround for local II dev, confirm
+`dummy_auth` is active. If DUMMY_AUTH is supposed to be on but isn't, the config
+is wrong — fix the config (or patch the check), don't simulate WebAuthn.
+
+---
+
+## 4-call credential conflict
+
+`04-deploy.sh` calls `derive-ii-principal` 4× against the same running II
+canister. Without the random seed patch, all 4 calls would derive the same
+Ed25519 key (seed 0 → 32 zero bytes credential ID). The first call registers it;
+calls 2–4 fail with "credential already registered".
+
+The `vz()` random seed patch ensures each CLI invocation creates a unique
+credential, so all 4 calls succeed independently.
+
+For Playwright E2E tests the same issue applies: each test gets a fresh browser
+context (no II session) but shares the same II canister. A per-context random
+seed (generated once in the `tests/fixtures.ts` fixture) prevents conflicts
+between tests while allowing the second II popup within the same test to reuse
+the existing session ("Continue" appears directly).
+
+---
+
+## Files changed
+
+| File | Purpose |
+|------|---------|
+| `packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs` | CLI: all 4 patches above |
+| `tests/fixtures.ts` | E2E tests: same 4 patches as a Playwright test fixture |
+| `tests/ii-helpers.ts` | Simplified II popup flow (CWP → "Create new identity" directly) |

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -174,15 +174,6 @@ async function main() {
     }
   );
 
-  await context.addInitScript(() => {
-    // On Linux headless, isUserVerifyingPlatformAuthenticatorAvailable() returns false,
-    // which causes II to hide the passkey UI. Override to always show it.
-    if (typeof PublicKeyCredential !== 'undefined') {
-      PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = () =>
-        Promise.resolve(true);
-    }
-  });
-
   const page = await context.newPage();
 
   // Intercept canister origin — the canister does not need to be running for

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -319,27 +319,45 @@ async function main() {
       } catch (e) { dbg('getPublicKey patch FAILED: ' + e.message); }
     }
 
-    // ── Fix 3: credentials.create() — store authData + none-attestation Proxy ─
-    // Store authData so Fix 1 can substitute it into 0-byte DataViews.
-    // Also wrap the credential in a Proxy that returns a "none" attestation object,
-    // so II skips packed-attestation signature verification.
-    function buildNoneAttestationCbor(authDataBuf) {
-      function ct(s) {
-        const b = [0x60 | s.length];
-        for (let i = 0; i < s.length; i++) b.push(s.charCodeAt(i));
-        return b;
+    // ── Fix 3: credentials.create() — synthetic authData + packed self-attestation ─
+    // Generate a fresh P-256 keypair + 148-byte synthetic authData with a 16-byte
+    // credId, replacing the CDP virtual authenticator's malformed output (64-byte
+    // credId leaves only 45 bytes for the COSE key — too short for P-256 at ~77b).
+    // Sign authData||SHA256(clientDataJSON) with the generated private key so that
+    // II's packed-attestation verification passes on both client and canister side.
+
+    function b64url(buf) {
+      return btoa(String.fromCharCode(...new Uint8Array(buf)))
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    }
+
+    // Convert SubtleCrypto ECDSA output (P1363: r||s, 64 bytes) to DER SEQUENCE.
+    function p1363ToDer(p1363Buf) {
+      const a = new Uint8Array(p1363Buf);
+      function encInt(b) {
+        let i = 0; while (i < b.length - 1 && b[i] === 0) i++;
+        b = b.slice(i);
+        if (b[0] & 0x80) b = new Uint8Array([0, ...b]);
+        return [0x02, b.length, ...b];
       }
-      const n = authDataBuf.byteLength;
-      const hdr = [
-        0xa3,
-        ...ct('fmt'), ...ct('none'),
-        ...ct('attStmt'), 0xa0,
-        ...ct('authData'),
-        ...(n <= 23 ? [0x40 | n] : n <= 255 ? [0x58, n] : [0x59, (n >> 8) & 0xff, n & 0xff]),
-      ];
+      const r = encInt(a.slice(0, 32)), s = encInt(a.slice(32, 64));
+      return new Uint8Array([0x30, r.length + s.length, ...r, ...s]).buffer;
+    }
+
+    function buildPackedAttestationCbor(authDataBuf, sigBuf) {
+      function ct(s) { const b=[0x60|s.length]; for(let i=0;i<s.length;i++) b.push(s.charCodeAt(i)); return b; }
+      function bstr(buf) {
+        const n = new Uint8Array(buf).length;
+        const p = n<=23?[0x40|n]:n<=255?[0x58,n]:[0x59,(n>>8)&0xff,n&0xff];
+        return [...p, ...new Uint8Array(buf)];
+      }
+      // attStmt: {alg: -7, sig: sigBuf} — 0xa2=map(2), 0x26=CBOR -7 (ES256)
+      const attStmt = [0xa2, ...ct('alg'), 0x26, ...ct('sig'), ...bstr(sigBuf)];
+      const n = new Uint8Array(authDataBuf).length;
+      const hdr = [0xa3, ...ct('fmt'), ...ct('packed'), ...ct('attStmt'), ...attStmt,
+        ...ct('authData'), ...(n<=23?[0x40|n]:n<=255?[0x58,n]:[0x59,(n>>8)&0xff,n&0xff])];
       const result = new Uint8Array(hdr.length + n);
-      result.set(hdr, 0);
-      result.set(new Uint8Array(authDataBuf), hdr.length);
+      result.set(hdr, 0); result.set(new Uint8Array(authDataBuf), hdr.length);
       return result.buffer;
     }
 
@@ -352,11 +370,8 @@ async function main() {
       if (!cred || !cred.response) return cred;
       dbg('credentials.create returned type=' + cred.type);
 
-      // Generate synthetic authData with a real P-256 key and a short 16-byte
-      // credential ID. CDP virtual authenticators use 64-byte credential IDs,
-      // leaving only ~45 bytes for the COSE key in a 164-byte authData — too
-      // short for a P-256 COSE key (~77 bytes), causing "Input too short".
-      let syntheticAuthData;
+      // Generate synthetic authData with a real P-256 key and a short 16-byte credId.
+      let syntheticAuthData, privateKey, credId;
       try {
         const cdpAD = cred.response.getAuthenticatorData();
         const rpIdHash = cdpAD && cdpAD.byteLength >= 32
@@ -365,10 +380,11 @@ async function main() {
         const kp = await crypto.subtle.generateKey(
           { name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']
         );
+        privateKey = kp.privateKey;
         const raw = new Uint8Array(await crypto.subtle.exportKey('raw', kp.publicKey));
         const x = raw.slice(1, 33), y = raw.slice(33, 65);
 
-        const credId = crypto.getRandomValues(new Uint8Array(16));
+        credId = crypto.getRandomValues(new Uint8Array(16));
         const cose = new Uint8Array([
           0xa5, 0x01, 0x02, 0x03, 0x26, 0x20, 0x01,
           0x21, 0x58, 0x20, ...x,
@@ -400,33 +416,50 @@ async function main() {
         } catch (e2) {}
       }
 
-      let noneAttestCbor;
-      try { noneAttestCbor = buildNoneAttestationCbor(syntheticAuthData); } catch(e) {}
-      if (noneAttestCbor) {
-        const synthAD = syntheticAuthData;
-        const realResp = cred.response;
-        const proxiedResp = new Proxy(realResp, {
-          get(target, prop) {
-            if (prop === 'attestationObject') {
-              dbg('intercepted attestationObject → none CBOR');
-              return noneAttestCbor;
-            }
-            if (prop === 'getAuthenticatorData') {
-              return () => synthAD;
-            }
-            const val = target[prop];
-            return typeof val === 'function' ? val.bind(target) : val;
-          },
-        });
-        cred = new Proxy(cred, {
-          get(target, prop) {
-            if (prop === 'response') return proxiedResp;
-            const val = target[prop];
-            return typeof val === 'function' ? val.bind(target) : val;
-          },
-        });
-        dbg('credential wrapped: synthetic authData + none-attestation');
+      if (!syntheticAuthData) return cred;
+
+      // Build packed self-attestation: sign authData||SHA256(clientDataJSON) with
+      // the private key whose public key is embedded in syntheticAuthData.
+      let attestCbor;
+      try {
+        const cldHash = await crypto.subtle.digest('SHA-256', cred.response.clientDataJSON);
+        const verifBuf = new Uint8Array(syntheticAuthData.byteLength + 32);
+        verifBuf.set(new Uint8Array(syntheticAuthData), 0);
+        verifBuf.set(new Uint8Array(cldHash), syntheticAuthData.byteLength);
+        const sigP1363 = await crypto.subtle.sign(
+          { name: 'ECDSA', hash: 'SHA-256' }, privateKey, verifBuf
+        );
+        const sigDer = p1363ToDer(sigP1363);
+        dbg('packed sig: ' + new Uint8Array(sigDer).length + 'b');
+        attestCbor = buildPackedAttestationCbor(syntheticAuthData, sigDer);
+        dbg('intercepted attestationObject → packed CBOR');
+      } catch (e) {
+        dbg('packed attestation FAILED: ' + e.message);
       }
+
+      if (!attestCbor) return cred;
+
+      const synthAD = syntheticAuthData;
+      const realResp = cred.response;
+      const proxiedResp = new Proxy(realResp, {
+        get(target, prop) {
+          if (prop === 'attestationObject') return attestCbor;
+          if (prop === 'getAuthenticatorData') return () => synthAD;
+          const val = target[prop];
+          return typeof val === 'function' ? val.bind(target) : val;
+        },
+      });
+      const credIdBuf = credId;
+      cred = new Proxy(cred, {
+        get(target, prop) {
+          if (prop === 'response') return proxiedResp;
+          if (prop === 'rawId' && credIdBuf) return credIdBuf.buffer;
+          if (prop === 'id' && credIdBuf) return b64url(credIdBuf);
+          const val = target[prop];
+          return typeof val === 'function' ? val.bind(target) : val;
+        },
+      });
+      dbg('credential wrapped: synthetic authData + packed self-attestation');
       return cred;
     };
 

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -11,13 +11,31 @@ const bundle = readFileSync(process.env.DAPP_BUNDLE_PATH, 'utf8');
  * Never attempts "Use existing identity" (fresh browser context has no stored key).
  */
 async function handleIIPopupAlwaysNew(popup) {
+  process.stderr.write(`[ii-popup] opened, initial URL: ${popup.url()}\n`);
+
+  // Capture console errors, page JS errors, and failed network requests from II.
+  popup.on('console', (msg) => {
+    if (msg.type() === 'error') process.stderr.write(`[ii-console] ${msg.text()}\n`);
+  });
+  popup.on('pageerror', (err) => process.stderr.write(`[ii-pageerror] ${err.message}\n`));
+  popup.on('requestfailed', (req) =>
+    process.stderr.write(`[ii-reqfailed] ${req.url()} — ${req.failure()?.errorText ?? '?'}\n`)
+  );
+
+  // Wait for the popup to navigate away from its initial about:blank state to II.
+  await popup
+    .waitForURL((url) => !url.href.startsWith('about:'), { timeout: 25000 })
+    .catch(() =>
+      process.stderr.write(`[ii-popup] still at about:blank after 25s — URL: ${popup.url()}\n`)
+    );
+  process.stderr.write(`[ii-popup] URL after navigation: ${popup.url()}\n`);
+
   // Use 'load' (not 'domcontentloaded') so the II SvelteKit app has finished
   // executing its JS before we look for buttons.
   await popup.waitForLoadState('load');
 
-  // Diagnostic: log what II actually renders so we can debug button-not-found failures.
   const bodyText = await popup.locator('body').innerText().catch(() => '<read error>');
-  process.stderr.write(`[ii-popup] rendered text (first 800): ${bodyText.slice(0, 800)}\n`);
+  process.stderr.write(`[ii-popup] body after load: ${bodyText.slice(0, 500)}\n`);
 
   const continueWithPasskey = popup.getByRole('button', {
     name: 'Continue with passkey',
@@ -28,10 +46,18 @@ async function handleIIPopupAlwaysNew(popup) {
     exact: true,
   });
 
-  await Promise.race([
-    continueWithPasskey.waitFor({ state: 'visible', timeout: 30000 }),
-    continueBtn.waitFor({ state: 'visible', timeout: 30000 }),
-  ]);
+  try {
+    await Promise.race([
+      continueWithPasskey.waitFor({ state: 'visible', timeout: 30000 }),
+      continueBtn.waitFor({ state: 'visible', timeout: 30000 }),
+    ]);
+  } catch (e) {
+    // Dump full HTML so we can see what II actually rendered on failure.
+    const html = await popup.content().catch(() => '<error reading content>');
+    process.stderr.write(`[ii-popup] URL at timeout: ${popup.url()}\n`);
+    process.stderr.write(`[ii-popup] HTML at timeout:\n${html.slice(0, 4000)}\n`);
+    throw e;
+  }
 
   if (await continueWithPasskey.isVisible()) {
     await continueWithPasskey.click();

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -176,6 +176,17 @@ async function main() {
     // Diagnostic: emitted as [ii-console] in stderr
     const dbg = (msg) => console.error('[dbg] ' + msg);
 
+    // Intercept DataView.getUint16 to log the buffer size and offset at failure.
+    // This tells us whether it's parsing the 91-byte DER from getPublicKey() or
+    // a different buffer (e.g. attestationObject CBOR).
+    const _origGU16 = DataView.prototype.getUint16;
+    DataView.prototype.getUint16 = function(offset, le) {
+      if (offset + 2 > this.byteLength) {
+        dbg('getUint16 OOB: offset=' + offset + ' byteLength=' + this.byteLength);
+      }
+      return _origGU16.call(this, offset, le);
+    };
+
     // CDP virtual authenticators on headless Linux return an empty buffer from
     // AuthenticatorAttestationResponse.getPublicKey(), which causes II's DER parser
     // (DataView.getUint16) to throw "Offset is outside the bounds of the DataView".
@@ -293,6 +304,9 @@ async function main() {
         let authDataLen = null;
         try { authDataLen = cred.response.getAuthenticatorData()?.byteLength; } catch(e) {}
         dbg('getAuthenticatorData byteLength=' + authDataLen);
+        let attObjLen = null;
+        try { attObjLen = cred.response.attestationObject?.byteLength; } catch(e) {}
+        dbg('attestationObject byteLength=' + attObjLen);
       }
       return cred;
     };

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -102,18 +102,23 @@ async function main() {
 
   // On Linux, headless Chromium has no platform authenticator, so
   // navigator.credentials.isUserVerifyingPlatformAuthenticatorAvailable()
-  // returns false and II hides the passkey UI. Add a virtual authenticator
-  // to every new page (including the II popup) so II renders the passkey flow.
-  // automaticPresenceSimulation (default true) auto-handles credentials.create()
-  // with no user interaction. On macOS this is a no-op — the real platform
-  // authenticator takes precedence.
+  // returns false and II hides the passkey UI. Use CDP to add a virtual
+  // platform authenticator to every new page (including the II popup) so
+  // II renders the passkey flow. automaticPresenceSimulation auto-handles
+  // credentials.create() with no user interaction. On macOS the real
+  // platform authenticator takes precedence — this is a no-op there.
   context.on('page', async (newPage) => {
-    await newPage.addVirtualAuthenticator({
-      protocol: 'ctap2',
-      transport: 'internal',
-      hasResidentKey: true,
-      hasUserVerification: true,
-      isUserVerified: true,
+    const cdp = await context.newCDPSession(newPage);
+    await cdp.send('WebAuthn.enable');
+    await cdp.send('WebAuthn.addVirtualAuthenticator', {
+      options: {
+        protocol: 'ctap2',
+        transport: 'internal',
+        hasResidentKey: true,
+        hasUserVerification: true,
+        isUserVerified: true,
+        automaticPresenceSimulation: true,
+      },
     });
   });
 

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -11,7 +11,7 @@ const bundle = readFileSync(process.env.DAPP_BUNDLE_PATH, 'utf8');
  * Never attempts "Use existing identity" (fresh browser context has no stored key).
  */
 async function handleIIPopupAlwaysNew(popup) {
-  // Use 'load' (not 'domcontentloaded') so the II React app has finished
+  // Use 'load' (not 'domcontentloaded') so the II SvelteKit app has finished
   // executing its JS before we look for buttons.
   await popup.waitForLoadState('load');
 
@@ -66,46 +66,56 @@ async function main() {
     (url) => url.hostname !== 'localhost' && url.hostname.endsWith('.localhost'),
     (route) => {
       const url = new URL(route.request().url());
-      process.stderr.write(`[proxy] intercepted: ${route.request().method()} ${url.href}\n`);
-      try {
-        // Use Node.js http directly so the Host header is sent exactly as set.
-        // route.fetch() derives Host from the target URL and ignores overrides,
-        // which breaks PocketIC's canister routing by subdomain.
-        const req = http.request(
-          {
-            hostname: '127.0.0.1',
-            port: parseInt(url.port) || 80,
-            path: url.pathname + url.search,
-            method: route.request().method(),
-            headers: { ...route.request().headers(), host: url.host },
-          },
-          (res) => {
-            process.stderr.write(`[proxy] response: ${res.statusCode} for ${url.href}\n`);
-            const chunks = [];
-            res.on('data', (c) => chunks.push(c));
-            res.on('end', () => {
-              const headers = {};
-              for (const [k, v] of Object.entries(res.headers)) {
-                headers[k] = Array.isArray(v) ? v.join('\n') : String(v);
-              }
-              route.fulfill({ status: res.statusCode, headers, body: Buffer.concat(chunks) })
-                .catch((e) => process.stderr.write(`[proxy] fulfill error: ${e.message}\n`));
-            });
-          }
-        );
-        req.on('error', (e) => {
-          process.stderr.write(`[proxy] request error: ${url.href}: ${e.message}\n`);
-          route.abort();
-        });
-        const body = route.request().postDataBuffer();
-        if (body) req.write(body);
-        req.end();
-      } catch (e) {
-        process.stderr.write(`[proxy] handler threw: ${e.message}\n`);
+      // Use Node.js http directly so the Host header is sent exactly as set.
+      // route.fetch() derives Host from the target URL and ignores overrides,
+      // which breaks PocketIC's canister routing by subdomain.
+      const req = http.request(
+        {
+          hostname: '127.0.0.1',
+          port: parseInt(url.port) || 80,
+          path: url.pathname + url.search,
+          method: route.request().method(),
+          headers: { ...route.request().headers(), host: url.host },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            const headers = {};
+            for (const [k, v] of Object.entries(res.headers)) {
+              headers[k] = Array.isArray(v) ? v.join('\n') : String(v);
+            }
+            route.fulfill({ status: res.statusCode, headers, body: Buffer.concat(chunks) })
+              .catch((e) => process.stderr.write(`[proxy] fulfill error: ${e.message}\n`));
+          });
+        }
+      );
+      req.on('error', (e) => {
+        process.stderr.write(`[proxy] request error: ${url.href}: ${e.message}\n`);
         route.abort();
-      }
+      });
+      const body = route.request().postDataBuffer();
+      if (body) req.write(body);
+      req.end();
     }
   );
+
+  // On Linux, headless Chromium has no platform authenticator, so
+  // navigator.credentials.isUserVerifyingPlatformAuthenticatorAvailable()
+  // returns false and II hides the passkey UI. Add a virtual authenticator
+  // to every new page (including the II popup) so II renders the passkey flow.
+  // automaticPresenceSimulation (default true) auto-handles credentials.create()
+  // with no user interaction. On macOS this is a no-op — the real platform
+  // authenticator takes precedence.
+  context.on('page', async (newPage) => {
+    await newPage.addVirtualAuthenticator({
+      protocol: 'ctap2',
+      transport: 'internal',
+      hasResidentKey: true,
+      hasUserVerification: true,
+      isUserVerified: true,
+    });
+  });
 
   const page = await context.newPage();
 

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -91,7 +91,6 @@ async function handleIIPopup(popup) {
         const btn = [...document.querySelectorAll('button')]
           .find((b) => b.textContent.trim() === 'Create new identity');
         if (!btn) return false;
-        process.stderr?.write?.('[ii-popup] removing disabled + dispatching click\n');
         btn.disabled = false;
         btn.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
         return true;

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -8,11 +8,16 @@ const identityProvider = process.env.DAPP_II_PROVIDER;
 const bundle = readFileSync(process.env.DAPP_BUNDLE_PATH, 'utf8');
 
 /**
- * Automate the II popup — always creates a new identity.
+ * Automate the II popup, matching the handleIIPopup flow from tests/ii-helpers.ts.
  *
- * The local NNS II provisioned by icp-cli (ii: true) is a test build that does
- * not verify WebAuthn attestation. Clicking through the UI is sufficient; no
- * CDP virtual authenticator or credential patching is needed.
+ * The local NNS II provisioned by icp-cli (ii: true) supports passkey-less auth:
+ * credentials.get() ("Use existing identity") works without a real authenticator,
+ * so we try that path first. "Create new identity" calls credentials.create()
+ * which hangs without an authenticator, so we only fall back to it if needed.
+ *
+ * Scenarios:
+ *  - First run (no stored identity): "Use existing" errors → "Create new identity"
+ *  - Returning session (same context): "Continue" appears directly
  */
 async function handleIIPopup(popup) {
   process.stderr.write(`[ii-popup] opened: ${popup.url()}\n`);
@@ -52,17 +57,36 @@ async function handleIIPopup(popup) {
   if (await continueWithPasskey.isVisible()) {
     await continueWithPasskey.click();
 
-    const createNewBtn = popup.getByRole('button', {
-      name: 'Create new identity',
+    // Try "Use existing identity" — in the local NNS II test build this works via
+    // credentials.get() without a real authenticator (passkey-less auth).
+    const useExistingBtn = popup.getByRole('button', {
+      name: 'Use existing identity',
       exact: true,
     });
-    await createNewBtn.waitFor({ state: 'visible', timeout: 20000 });
-    await createNewBtn.click();
+    await useExistingBtn.waitFor({ state: 'visible', timeout: 10000 });
+    await useExistingBtn.click();
 
-    const nameInput = popup.locator('input[placeholder="Identity name"]');
-    await nameInput.waitFor({ state: 'visible', timeout: 20000 });
-    await nameInput.fill('Test');
-    await popup.getByRole('button', { name: 'Create identity', exact: true }).click();
+    // If no identity exists yet, II shows an error; fall back to creating one.
+    const errorVisible = await popup
+      .getByText('Cannot read properties of undefined')
+      .waitFor({ state: 'visible', timeout: 3000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (errorVisible) {
+      process.stderr.write(`[ii-popup] use-existing failed — creating new identity\n`);
+      const createNewBtn = popup.getByRole('button', {
+        name: 'Create new identity',
+        exact: true,
+      });
+      await createNewBtn.waitFor({ state: 'visible', timeout: 10000 });
+      await createNewBtn.click();
+
+      const nameInput = popup.locator('input[placeholder="Identity name"]');
+      await nameInput.waitFor({ state: 'visible', timeout: 10000 });
+      await nameInput.fill('Test');
+      await popup.getByRole('button', { name: 'Create identity', exact: true }).click();
+    }
 
     await continueBtn.waitFor({ state: 'visible', timeout: 30000 });
   }

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -175,18 +175,29 @@ async function main() {
     }
   );
 
-  // The II /authorize page calls credentials.get() with empty allowCredentials on mount
-  // for passkey autofill/discovery. On headless Linux Chrome this throws NotSupportedError
-  // and prevents the passkey UI from rendering.
+  // The II /authorize page on headless Linux needs two patches to render its button UI:
   //
-  // Intercept discoverable-credential calls (allowCredentials undefined or empty) and
-  // reject with NotAllowedError, which II treats as "no passkeys found" and renders the
-  // button UI normally. Non-discoverable calls (allowCredentials non-empty) pass through
-  // to the real implementation — the local II dev build handles those without a real
-  // authenticator (DUMMY_AUTH mode).
+  // 1. isUserVerifyingPlatformAuthenticatorAvailable() returns false on headless Linux.
+  //    II checks this to enable/disable the "Create new identity" button. Override it to
+  //    return true so the button is enabled.
+  //
+  // 2. credentials.get() with empty allowCredentials (discoverable/autofill call) throws
+  //    NotSupportedError on headless Linux, blocking UI render. Intercept and reject with
+  //    NotAllowedError instead — II treats that as "no passkeys found" and shows buttons.
+  //    Non-discoverable calls (allowCredentials non-empty) pass through.
+  //
+  // The local II dev build (icp-cli, ii: true) uses DUMMY_AUTH (M0 class) — no WebAuthn
+  // hardware or CDP virtual authenticators are needed. M0.createNew/useExisting just
+  // return Promise.resolve() without calling any WebAuthn APIs.
   //
   // addInitScript runs on ALL pages (including the II popup) before any page JavaScript.
   await context.addInitScript(() => {
+    try {
+      if (typeof PublicKeyCredential !== 'undefined') {
+        PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = () =>
+          Promise.resolve(true);
+      }
+    } catch (_) {}
     try {
       const _origGet = navigator.credentials.get.bind(navigator.credentials);
       navigator.credentials.get = function(options) {

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -249,6 +249,51 @@ async function main() {
     } else {
       dbg('AuthenticatorAttestationResponse not available in initScript');
     }
+
+    // Wrap credentials.create() for diagnostics — also check whether our prototype
+    // patch is actually reachable via the returned response object.
+    const _origCreate = navigator.credentials.create.bind(navigator.credentials);
+    navigator.credentials.create = async function(options) {
+      dbg('credentials.create called');
+      let cred;
+      try {
+        cred = await _origCreate(options);
+      } catch (e) {
+        dbg('credentials.create THREW: ' + e.message);
+        throw e;
+      }
+      dbg('credentials.create returned type=' + (cred ? cred.type : 'null'));
+      if (cred && cred.response) {
+        dbg('response instanceof AuthenticatorAttestationResponse: ' +
+            (cred.response instanceof AuthenticatorAttestationResponse));
+        dbg('response.getPublicKey is patched: ' +
+            (cred.response.getPublicKey !== (typeof AuthenticatorAttestationResponse !== 'undefined'
+              ? AuthenticatorAttestationResponse.prototype.getPublicKey : null)));
+        let pk = null;
+        try { pk = cred.response.getPublicKey(); } catch (e) { dbg('getPublicKey threw: ' + e.message); }
+        dbg('getPublicKey byteLength=' + (pk ? pk.byteLength : 'null'));
+        let authDataLen = null;
+        try { authDataLen = cred.response.getAuthenticatorData()?.byteLength; } catch(e) {}
+        dbg('getAuthenticatorData byteLength=' + authDataLen);
+      }
+      return cred;
+    };
+
+    // Wrap credentials.get() — during II initialization, II issues a conditional-
+    // mediation request to enable passkey autofill. With automaticPresenceSimulation:true
+    // the CDP authenticator auto-responds, which can cause II to process an assertion
+    // response it doesn't expect and throw a DataView error. Return null for these
+    // silent background requests so the flow isn't disrupted.
+    const _origGet = navigator.credentials.get.bind(navigator.credentials);
+    navigator.credentials.get = async function(options) {
+      const mediation = options?.mediation;
+      dbg('credentials.get called mediation=' + mediation);
+      if (mediation === 'conditional') {
+        dbg('credentials.get: conditional → returning null to block CDP auto-response');
+        return null;
+      }
+      return _origGet(options);
+    };
   });
 
   context.on('page', async (newPage) => {

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -8,35 +8,25 @@ const identityProvider = process.env.DAPP_II_PROVIDER;
 const bundle = readFileSync(process.env.DAPP_BUNDLE_PATH, 'utf8');
 
 /**
- * Automate the II popup — ALWAYS creates a new identity.
- * Never attempts "Use existing identity" (fresh browser context has no stored key).
+ * Automate the II popup — always creates a new identity.
+ *
+ * The local NNS II provisioned by icp-cli (ii: true) is a test build that does
+ * not verify WebAuthn attestation. Clicking through the UI is sufficient; no
+ * CDP virtual authenticator or credential patching is needed.
  */
-async function handleIIPopupAlwaysNew(popup) {
-  process.stderr.write(`[ii-popup] opened, initial URL: ${popup.url()}\n`);
-
-  // Capture console errors, page JS errors, and failed network requests from II.
-  popup.on('console', (msg) => {
-    if (msg.type() === 'error') process.stderr.write(`[ii-console] ${msg.text()}\n`);
-  });
+async function handleIIPopup(popup) {
+  process.stderr.write(`[ii-popup] opened: ${popup.url()}\n`);
   popup.on('pageerror', (err) => process.stderr.write(`[ii-pageerror] ${err.message}\n`));
   popup.on('requestfailed', (req) =>
     process.stderr.write(`[ii-reqfailed] ${req.url()} — ${req.failure()?.errorText ?? '?'}\n`)
   );
 
-  // Wait for the popup to navigate away from its initial about:blank state to II.
   await popup
     .waitForURL((url) => !url.href.startsWith('about:'), { timeout: 25000 })
-    .catch(() =>
-      process.stderr.write(`[ii-popup] still at about:blank after 25s — URL: ${popup.url()}\n`)
-    );
+    .catch(() => process.stderr.write(`[ii-popup] still at about:blank after 25s\n`));
+
   process.stderr.write(`[ii-popup] URL after navigation: ${popup.url()}\n`);
-
-  // Use 'load' (not 'domcontentloaded') so the II SvelteKit app has finished
-  // executing its JS before we look for buttons.
   await popup.waitForLoadState('load');
-
-  const bodyText = await popup.locator('body').innerText().catch(() => '<read error>');
-  process.stderr.write(`[ii-popup] body after load: ${bodyText.slice(0, 500)}\n`);
 
   const continueWithPasskey = popup.getByRole('button', {
     name: 'Continue with passkey',
@@ -53,17 +43,15 @@ async function handleIIPopupAlwaysNew(popup) {
       continueBtn.waitFor({ state: 'visible', timeout: 30000 }),
     ]);
   } catch (e) {
-    // Dump full HTML so we can see what II actually rendered on failure.
     const html = await popup.content().catch(() => '<error reading content>');
-    process.stderr.write(`[ii-popup] URL at timeout: ${popup.url()}\n`);
-    process.stderr.write(`[ii-popup] HTML at timeout:\n${html.slice(0, 4000)}\n`);
+    process.stderr.write(`[ii-popup] timeout. URL: ${popup.url()}\n`);
+    process.stderr.write(`[ii-popup] HTML:\n${html.slice(0, 3000)}\n`);
     throw e;
   }
 
   if (await continueWithPasskey.isVisible()) {
     await continueWithPasskey.click();
 
-    // Skip "Use existing identity" — go directly to "Create new identity"
     const createNewBtn = popup.getByRole('button', {
       name: 'Create new identity',
       exact: true,
@@ -84,7 +72,6 @@ async function handleIIPopupAlwaysNew(popup) {
 
 async function main() {
   const browser = await chromium.launch({ headless: true });
-  // Fresh context = no stored passkey identity
   const context = await browser.newContext();
 
   // On Linux, Chromium's built-in DNS resolver does not reliably resolve
@@ -97,9 +84,6 @@ async function main() {
     (url) => url.hostname !== 'localhost' && url.hostname.endsWith('.localhost'),
     (route) => {
       const url = new URL(route.request().url());
-      // Use Node.js http directly so the Host header is sent exactly as set.
-      // route.fetch() derives Host from the target URL and ignores overrides,
-      // which breaks PocketIC's canister routing by subdomain.
       const req = http.request(
         {
           hostname: '127.0.0.1',
@@ -116,10 +100,11 @@ async function main() {
             const encoding = (res.headers['content-encoding'] || '').toLowerCase();
 
             // route.fulfill() passes the body directly to Chrome without applying
-            // content-encoding — we must decompress here or Chrome will try to parse
-            // gzip/brotli bytes as HTML/JS and fail with "Invalid or unexpected token".
-            // Also strip hop-by-hop headers that don't apply to a fulfilled response.
-            const HOP_BY_HOP = new Set(['content-encoding', 'transfer-encoding', 'connection', 'keep-alive']);
+            // content-encoding — decompress here or Chrome parses compressed bytes
+            // as HTML/JS and fails with "Invalid or unexpected token".
+            const HOP_BY_HOP = new Set([
+              'content-encoding', 'transfer-encoding', 'connection', 'keep-alive',
+            ]);
             const headers = {};
             for (const [k, v] of Object.entries(res.headers)) {
               if (!HOP_BY_HOP.has(k)) headers[k] = Array.isArray(v) ? v.join('\n') : String(v);
@@ -127,15 +112,10 @@ async function main() {
 
             let body;
             try {
-              if (encoding === 'gzip' || encoding === 'x-gzip') {
-                body = zlib.gunzipSync(rawBody);
-              } else if (encoding === 'br') {
-                body = zlib.brotliDecompressSync(rawBody);
-              } else if (encoding === 'deflate') {
-                body = zlib.inflateSync(rawBody);
-              } else {
-                body = rawBody;
-              }
+              if (encoding === 'gzip' || encoding === 'x-gzip') body = zlib.gunzipSync(rawBody);
+              else if (encoding === 'br') body = zlib.brotliDecompressSync(rawBody);
+              else if (encoding === 'deflate') body = zlib.inflateSync(rawBody);
+              else body = rawBody;
             } catch (e) {
               process.stderr.write(`[proxy] decompress error (${encoding}): ${e.message}\n`);
               body = rawBody;
@@ -156,347 +136,20 @@ async function main() {
     }
   );
 
-  // On Linux, headless Chromium has no platform authenticator, so
-  // PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
-  // returns false and II hides the passkey UI.
-  //
-  // Two-part fix:
-  //   1. addInitScript: overrides isUserVerifyingPlatformAuthenticatorAvailable
-  //      synchronously BEFORE any page JS runs, so II always sees true.
-  //      This avoids the race between II's SvelteKit boot and our async CDP setup.
-  //   2. CDP virtual authenticator: handles credentials.create() / credentials.get()
-  //      called later in the flow after the user clicks through the II UI.
-  //      On macOS the real platform authenticator takes precedence — both are no-ops.
+  // On Linux headless, PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
+  // returns false, which may cause II to suppress the passkey UI. Override it so
+  // the "Continue with passkey" button always appears.
   await context.addInitScript(() => {
     if (typeof PublicKeyCredential !== 'undefined') {
       PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = () =>
         Promise.resolve(true);
     }
-
-    const dbg = (msg) => console.error('[dbg] ' + msg);
-
-    // ── Fix 1: DataView constructor substitution ─────────────────────────────
-    // II's CBOR decoder (called from uz→pz→sign→createNew) returns a 0-byte
-    // ArrayBuffer for authData when decoding attestationObject. II then creates
-    // new DataView(0-byte) and calls getUint16(53) to read credentialIdLength,
-    // which throws RangeError.
-    //
-    // Root cause: II's CBOR decoder has a bug that produces a 0-byte buffer for
-    // the authData field regardless of attestation format.
-    //
-    // Fix: intercept the DataView constructor. When a 0-byte buffer is passed
-    // and we have a stored authData, substitute the real authData so II can parse
-    // it correctly. The DataView object then covers the full 164-byte authData.
-    const _authDataRef = { buf: null };
-    const _OrigDataView = DataView;
-    const _OrigDVProto = _OrigDataView.prototype;
-
-    function PatchedDataView(buffer, byteOffset, byteLength) {
-      const bLen = buffer && typeof buffer.byteLength === 'number' ? buffer.byteLength : 0;
-      const effective = byteLength !== undefined ? byteLength :
-        byteOffset !== undefined ? bLen - (byteOffset || 0) : bLen;
-      if (effective === 0 && _authDataRef.buf) {
-        dbg('DataView(0-byte) → substituting stored authData');
-        return new _OrigDataView(_authDataRef.buf);
-      }
-      if (byteOffset !== undefined && byteLength !== undefined)
-        return new _OrigDataView(buffer, byteOffset, byteLength);
-      if (byteOffset !== undefined)
-        return new _OrigDataView(buffer, byteOffset);
-      return new _OrigDataView(buffer);
-    }
-    PatchedDataView.prototype = _OrigDVProto;
-    Object.setPrototypeOf(PatchedDataView, _OrigDataView);
-    window.DataView = PatchedDataView;
-
-    // ── Fix 5: Uint8Array.prototype.subarray/slice on 0-byte arrays ──────────
-    // uz calls authData.subarray(55+credIdLen) to extract the COSE key bytes
-    // for CBOR decoding. But authData is a 0-byte Uint8Array (CBOR decoder bug —
-    // it creates a 0-byte slice even though our "none" CBOR correctly encodes
-    // authData as 148 bytes). The DataView substitution above fixes credIdLen
-    // reading but uz still uses the original 0-byte array to extract COSE bytes.
-    const _origSubarray = Uint8Array.prototype.subarray;
-    Uint8Array.prototype.subarray = function(begin, end) {
-      if (this.byteLength === 0 && _authDataRef.buf) {
-        const result = _origSubarray.call(new Uint8Array(_authDataRef.buf), begin, end);
-        dbg('Uint8Array(0).subarray(' + begin + ') → synth(' + result.byteLength + 'b)');
-        return result;
-      }
-      return _origSubarray.call(this, begin, end);
-    };
-    const _origSlice = Uint8Array.prototype.slice;
-    Uint8Array.prototype.slice = function(begin, end) {
-      if (this.byteLength === 0 && _authDataRef.buf) {
-        const result = _origSlice.call(new Uint8Array(_authDataRef.buf), begin, end);
-        dbg('Uint8Array(0).slice(' + begin + ') → synth(' + result.byteLength + 'b)');
-        return result;
-      }
-      return _origSlice.call(this, begin, end);
-    };
-
-    // ── Fix 6: Object.prototype.entries shim for CBOR-decoded COSE key ──────
-    // cbor-x (used by II) returns plain JS objects for CBOR maps, with integer
-    // keys coerced to strings ("-2", "-3", etc.). uz calls n.entries() expecting
-    // a Map-like iterator with integer keys. In normal macOS flow, getPublicKey()
-    // returns valid DER so this COSE parse path is never reached. With CDP
-    // virtual authenticators, getPublicKey() is empty and uz hits this dead code.
-    // Add .entries() to Object.prototype (non-enumerable) with integer key
-    // conversion so plain CBOR-decoded objects work as drop-in Map replacements.
-    if (!Object.prototype.entries) {
-      Object.defineProperty(Object.prototype, 'entries', {
-        value: function() {
-          return Object.entries(this).map(([k, v]) => [
-            /^-?\d+$/.test(k) ? parseInt(k, 10) : k,
-            v,
-          ])[Symbol.iterator]();
-        },
-        writable: true, configurable: true, enumerable: false,
-      });
-      dbg('Object.prototype.entries shim installed');
-    }
-
-    // Log OOB DataView reads to diagnose any remaining issues.
-    const _origGU16 = _OrigDVProto.getUint16;
-    _OrigDVProto.getUint16 = function(offset, le) {
-      if (offset + 2 > this.byteLength)
-        dbg('getUint16 OOB: offset=' + offset + ' byteLength=' + this.byteLength);
-      return _origGU16.call(this, offset, le);
-    };
-
-    // ── Fix 2: getPublicKey() → COSE-derived DER ─────────────────────────────
-    // CDP virtual authenticators return malformed DER from getPublicKey().
-    // Re-build correct DER from the COSE key in getAuthenticatorData().
-    function buildDerFromAuthData(authDataBuf) {
-      const authData = new Uint8Array(authDataBuf);
-      let offset = 53;
-      const credIdLen = (authData[offset] << 8) | authData[offset + 1];
-      offset += 2 + credIdLen;
-      const cose = authData.subarray(offset);
-      dbg('buildDer: credIdLen=' + credIdLen + ' cose.length=' + cose.length);
-      let xi = -1, yi = -1;
-      for (let i = 0; i < cose.length - 67; i++) {
-        if (cose[i] === 0x21 && cose[i+1] === 0x58 && cose[i+2] === 0x20 &&
-            cose[i+35] === 0x22 && cose[i+36] === 0x58 && cose[i+37] === 0x20) {
-          xi = i + 3; yi = i + 38; break;
-        }
-      }
-      if (xi < 0) return null;
-      const der = new Uint8Array(91);
-      const prefix = [
-        0x30, 0x59, 0x30, 0x13,
-        0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01,
-        0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07,
-        0x03, 0x42, 0x00, 0x04,
-      ];
-      prefix.forEach((b, i) => { der[i] = b; });
-      der.set(cose.subarray(xi, xi + 32), prefix.length);
-      der.set(cose.subarray(yi, yi + 32), prefix.length + 32);
-      return der.buffer;
-    }
-
-    if (typeof AuthenticatorAttestationResponse !== 'undefined') {
-      const proto = AuthenticatorAttestationResponse.prototype;
-      const origGetPK = proto.getPublicKey;
-      try {
-        Object.defineProperty(proto, 'getPublicKey', {
-          value: function() {
-            dbg('getPublicKey called');
-            const adBuf = _authDataRef.buf;
-            if (adBuf) {
-              try {
-                const der = buildDerFromAuthData(adBuf);
-                if (der) { dbg('getPublicKey → COSE-derived DER (91b)'); return der; }
-              } catch (e) { dbg('buildDer error: ' + e.message); }
-            }
-            let nativePk = null;
-            try { nativePk = origGetPK.call(this); } catch(e) {}
-            dbg('getPublicKey → native (' + (nativePk?.byteLength ?? 'null') + 'b)');
-            return nativePk;
-          },
-          writable: true, configurable: true,
-        });
-        dbg('getPublicKey patched');
-      } catch (e) { dbg('getPublicKey patch FAILED: ' + e.message); }
-    }
-
-    // ── Fix 3: credentials.create() — synthetic authData + packed self-attestation ─
-    // Generate a fresh P-256 keypair + 148-byte synthetic authData with a 16-byte
-    // credId, replacing the CDP virtual authenticator's malformed output (64-byte
-    // credId leaves only 45 bytes for the COSE key — too short for P-256 at ~77b).
-    // Sign authData||SHA256(clientDataJSON) with the generated private key so that
-    // II's packed-attestation verification passes on both client and canister side.
-
-    function b64url(buf) {
-      return btoa(String.fromCharCode(...new Uint8Array(buf)))
-        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-    }
-
-    // Convert SubtleCrypto ECDSA output (P1363: r||s, 64 bytes) to DER SEQUENCE.
-    function p1363ToDer(p1363Buf) {
-      const a = new Uint8Array(p1363Buf);
-      function encInt(b) {
-        let i = 0; while (i < b.length - 1 && b[i] === 0) i++;
-        b = b.slice(i);
-        if (b[0] & 0x80) b = new Uint8Array([0, ...b]);
-        return [0x02, b.length, ...b];
-      }
-      const r = encInt(a.slice(0, 32)), s = encInt(a.slice(32, 64));
-      return new Uint8Array([0x30, r.length + s.length, ...r, ...s]).buffer;
-    }
-
-    function buildPackedAttestationCbor(authDataBuf, sigBuf) {
-      function ct(s) { const b=[0x60|s.length]; for(let i=0;i<s.length;i++) b.push(s.charCodeAt(i)); return b; }
-      function bstr(buf) {
-        const n = new Uint8Array(buf).length;
-        const p = n<=23?[0x40|n]:n<=255?[0x58,n]:[0x59,(n>>8)&0xff,n&0xff];
-        return [...p, ...new Uint8Array(buf)];
-      }
-      // attStmt: {alg: -7, sig: sigBuf} — 0xa2=map(2), 0x26=CBOR -7 (ES256)
-      const attStmt = [0xa2, ...ct('alg'), 0x26, ...ct('sig'), ...bstr(sigBuf)];
-      const n = new Uint8Array(authDataBuf).length;
-      const hdr = [0xa3, ...ct('fmt'), ...ct('packed'), ...ct('attStmt'), ...attStmt,
-        ...ct('authData'), ...(n<=23?[0x40|n]:n<=255?[0x58,n]:[0x59,(n>>8)&0xff,n&0xff])];
-      const result = new Uint8Array(hdr.length + n);
-      result.set(hdr, 0); result.set(new Uint8Array(authDataBuf), hdr.length);
-      return result.buffer;
-    }
-
-    const _origCreate = navigator.credentials.create.bind(navigator.credentials);
-    navigator.credentials.create = async function(options) {
-      dbg('credentials.create called');
-      let cred;
-      try { cred = await _origCreate(options); }
-      catch (e) { dbg('credentials.create THREW: ' + e.message); throw e; }
-      if (!cred || !cred.response) return cred;
-      dbg('credentials.create returned type=' + cred.type);
-
-      // Generate synthetic authData with a real P-256 key and a short 16-byte credId.
-      let syntheticAuthData, privateKey, credId;
-      try {
-        const cdpAD = cred.response.getAuthenticatorData();
-        const rpIdHash = cdpAD && cdpAD.byteLength >= 32
-          ? new Uint8Array(cdpAD).slice(0, 32) : new Uint8Array(32);
-
-        const kp = await crypto.subtle.generateKey(
-          { name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']
-        );
-        privateKey = kp.privateKey;
-        const raw = new Uint8Array(await crypto.subtle.exportKey('raw', kp.publicKey));
-        const x = raw.slice(1, 33), y = raw.slice(33, 65);
-
-        credId = crypto.getRandomValues(new Uint8Array(16));
-        const cose = new Uint8Array([
-          0xa5, 0x01, 0x02, 0x03, 0x26, 0x20, 0x01,
-          0x21, 0x58, 0x20, ...x,
-          0x22, 0x58, 0x20, ...y,
-        ]);
-
-        const ad = new Uint8Array(55 + credId.length + cose.length);
-        let off = 0;
-        ad.set(rpIdHash, off); off += 32;
-        ad[off++] = 0x45; // flags: UP | UV | AT
-        off += 4; // signCount = 0
-        off += 16; // aaguid = zeros
-        ad[off++] = 0; ad[off++] = credId.length;
-        ad.set(credId, off); off += credId.length;
-        ad.set(cose, off);
-
-        syntheticAuthData = ad.buffer;
-        _authDataRef.buf = syntheticAuthData;
-        dbg('synthetic authData: ' + ad.length + 'b (credIdLen=' + credId.length + ')');
-      } catch (e) {
-        dbg('synthetic authData FAILED: ' + e.message);
-        try {
-          const cdpAD = cred.response.getAuthenticatorData();
-          if (cdpAD && cdpAD.byteLength > 0) {
-            syntheticAuthData = cdpAD;
-            _authDataRef.buf = cdpAD;
-            dbg('CDP authData fallback: ' + cdpAD.byteLength + 'b');
-          }
-        } catch (e2) {}
-      }
-
-      if (!syntheticAuthData) return cred;
-
-      // Build packed self-attestation: sign authData||SHA256(clientDataJSON) with
-      // the private key whose public key is embedded in syntheticAuthData.
-      let attestCbor;
-      try {
-        const cldHash = await crypto.subtle.digest('SHA-256', cred.response.clientDataJSON);
-        const verifBuf = new Uint8Array(syntheticAuthData.byteLength + 32);
-        verifBuf.set(new Uint8Array(syntheticAuthData), 0);
-        verifBuf.set(new Uint8Array(cldHash), syntheticAuthData.byteLength);
-        const sigP1363 = await crypto.subtle.sign(
-          { name: 'ECDSA', hash: 'SHA-256' }, privateKey, verifBuf
-        );
-        const sigDer = p1363ToDer(sigP1363);
-        dbg('packed sig: ' + new Uint8Array(sigDer).length + 'b');
-        attestCbor = buildPackedAttestationCbor(syntheticAuthData, sigDer);
-        dbg('intercepted attestationObject → packed CBOR');
-      } catch (e) {
-        dbg('packed attestation FAILED: ' + e.message);
-      }
-
-      if (!attestCbor) return cred;
-
-      const synthAD = syntheticAuthData;
-      const realResp = cred.response;
-      const proxiedResp = new Proxy(realResp, {
-        get(target, prop) {
-          if (prop === 'attestationObject') return attestCbor;
-          if (prop === 'getAuthenticatorData') return () => synthAD;
-          const val = target[prop];
-          return typeof val === 'function' ? val.bind(target) : val;
-        },
-      });
-      const credIdBuf = credId;
-      cred = new Proxy(cred, {
-        get(target, prop) {
-          if (prop === 'response') return proxiedResp;
-          if (prop === 'rawId' && credIdBuf) return credIdBuf.buffer;
-          if (prop === 'id' && credIdBuf) return b64url(credIdBuf);
-          const val = target[prop];
-          return typeof val === 'function' ? val.bind(target) : val;
-        },
-      });
-      dbg('credential wrapped: synthetic authData + packed self-attestation');
-      return cred;
-    };
-
-    // ── Fix 4: credentials.get() — block conditional mediation ───────────────
-    // II calls credentials.get({mediation:'conditional'}) during init for passkey
-    // autofill. With automaticPresenceSimulation:true, the CDP authenticator would
-    // auto-respond, disrupting the flow. Return null to block this.
-    const _origGet = navigator.credentials.get.bind(navigator.credentials);
-    navigator.credentials.get = async function(options) {
-      dbg('credentials.get mediation=' + options?.mediation);
-      if (options?.mediation === 'conditional') return null;
-      return _origGet(options);
-    };
-  });
-
-  context.on('page', async (newPage) => {
-    try {
-      const cdp = await context.newCDPSession(newPage);
-      await cdp.send('WebAuthn.enable');
-      await cdp.send('WebAuthn.addVirtualAuthenticator', {
-        options: {
-          protocol: 'ctap2',
-          transport: 'internal',
-          hasResidentKey: true,
-          hasUserVerification: true,
-          isUserVerified: true,
-          automaticPresenceSimulation: true,
-        },
-      });
-    } catch (e) {
-      process.stderr.write(`[webauthn] CDP setup failed: ${e.message}\n`);
-    }
   });
 
   const page = await context.newPage();
 
-  // Intercept canister origin — canister does not need to be running
+  // Intercept canister origin — the canister does not need to be running for
+  // principal derivation; we only need a page at that origin to trigger II auth.
   await page.route(`${canisterOrigin}/**`, (route) =>
     route.fulfill({
       status: 200,
@@ -514,7 +167,7 @@ async function main() {
   await page.click('[data-tid="login-button"]');
   const popup = await popupPromise;
 
-  await handleIIPopupAlwaysNew(popup);
+  await handleIIPopup(popup);
   await popup.waitForEvent('close', { timeout: 30000 });
 
   await page.waitForFunction(

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -15,6 +15,10 @@ async function handleIIPopupAlwaysNew(popup) {
   // executing its JS before we look for buttons.
   await popup.waitForLoadState('load');
 
+  // Diagnostic: log what II actually renders so we can debug button-not-found failures.
+  const bodyText = await popup.locator('body').innerText().catch(() => '<read error>');
+  process.stderr.write(`[ii-popup] rendered text (first 800): ${bodyText.slice(0, 800)}\n`);
+
   const continueWithPasskey = popup.getByRole('button', {
     name: 'Continue with passkey',
     exact: true,
@@ -101,25 +105,40 @@ async function main() {
   );
 
   // On Linux, headless Chromium has no platform authenticator, so
-  // navigator.credentials.isUserVerifyingPlatformAuthenticatorAvailable()
-  // returns false and II hides the passkey UI. Use CDP to add a virtual
-  // platform authenticator to every new page (including the II popup) so
-  // II renders the passkey flow. automaticPresenceSimulation auto-handles
-  // credentials.create() with no user interaction. On macOS the real
-  // platform authenticator takes precedence — this is a no-op there.
+  // PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
+  // returns false and II hides the passkey UI.
+  //
+  // Two-part fix:
+  //   1. addInitScript: overrides isUserVerifyingPlatformAuthenticatorAvailable
+  //      synchronously BEFORE any page JS runs, so II always sees true.
+  //      This avoids the race between II's SvelteKit boot and our async CDP setup.
+  //   2. CDP virtual authenticator: handles credentials.create() / credentials.get()
+  //      called later in the flow after the user clicks through the II UI.
+  //      On macOS the real platform authenticator takes precedence — both are no-ops.
+  await context.addInitScript(() => {
+    if (typeof PublicKeyCredential !== 'undefined') {
+      PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = () =>
+        Promise.resolve(true);
+    }
+  });
+
   context.on('page', async (newPage) => {
-    const cdp = await context.newCDPSession(newPage);
-    await cdp.send('WebAuthn.enable');
-    await cdp.send('WebAuthn.addVirtualAuthenticator', {
-      options: {
-        protocol: 'ctap2',
-        transport: 'internal',
-        hasResidentKey: true,
-        hasUserVerification: true,
-        isUserVerified: true,
-        automaticPresenceSimulation: true,
-      },
-    });
+    try {
+      const cdp = await context.newCDPSession(newPage);
+      await cdp.send('WebAuthn.enable');
+      await cdp.send('WebAuthn.addVirtualAuthenticator', {
+        options: {
+          protocol: 'ctap2',
+          transport: 'internal',
+          hasResidentKey: true,
+          hasUserVerification: true,
+          isUserVerified: true,
+          automaticPresenceSimulation: true,
+        },
+      });
+    } catch (e) {
+      process.stderr.write(`[webauthn] CDP setup failed: ${e.message}\n`);
+    }
   });
 
   const page = await context.newPage();

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -1,6 +1,7 @@
 import { chromium } from '@playwright/test';
 import { readFileSync } from 'fs';
 import http from 'http';
+import zlib from 'zlib';
 
 const canisterOrigin = process.env.DAPP_CANISTER_ORIGIN;
 const identityProvider = process.env.DAPP_II_PROVIDER;
@@ -111,11 +112,36 @@ async function main() {
           const chunks = [];
           res.on('data', (c) => chunks.push(c));
           res.on('end', () => {
+            const rawBody = Buffer.concat(chunks);
+            const encoding = (res.headers['content-encoding'] || '').toLowerCase();
+
+            // route.fulfill() passes the body directly to Chrome without applying
+            // content-encoding — we must decompress here or Chrome will try to parse
+            // gzip/brotli bytes as HTML/JS and fail with "Invalid or unexpected token".
+            // Also strip hop-by-hop headers that don't apply to a fulfilled response.
+            const HOP_BY_HOP = new Set(['content-encoding', 'transfer-encoding', 'connection', 'keep-alive']);
             const headers = {};
             for (const [k, v] of Object.entries(res.headers)) {
-              headers[k] = Array.isArray(v) ? v.join('\n') : String(v);
+              if (!HOP_BY_HOP.has(k)) headers[k] = Array.isArray(v) ? v.join('\n') : String(v);
             }
-            route.fulfill({ status: res.statusCode, headers, body: Buffer.concat(chunks) })
+
+            let body;
+            try {
+              if (encoding === 'gzip' || encoding === 'x-gzip') {
+                body = zlib.gunzipSync(rawBody);
+              } else if (encoding === 'br') {
+                body = zlib.brotliDecompressSync(rawBody);
+              } else if (encoding === 'deflate') {
+                body = zlib.inflateSync(rawBody);
+              } else {
+                body = rawBody;
+              }
+            } catch (e) {
+              process.stderr.write(`[proxy] decompress error (${encoding}): ${e.message}\n`);
+              body = rawBody;
+            }
+
+            route.fulfill({ status: res.statusCode, headers, body })
               .catch((e) => process.stderr.write(`[proxy] fulfill error: ${e.message}\n`));
           });
         }

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -174,14 +174,24 @@ async function main() {
     }
   );
 
-  // On Linux headless, PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
-  // returns false, which may cause II to suppress the passkey UI. Override it so
-  // the "Continue with passkey" button always appears.
   await context.addInitScript(() => {
+    // On Linux headless, isUserVerifyingPlatformAuthenticatorAvailable() returns false,
+    // which causes II to hide the passkey UI. Override to always show it.
     if (typeof PublicKeyCredential !== 'undefined') {
       PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = () =>
         Promise.resolve(true);
     }
+
+    // On Linux headless, credentials.get() with empty allowCredentials (resident/
+    // discoverable credential discovery) throws NotSupportedError, which prevents
+    // II from rendering its passkey UI. Return null instead so II proceeds normally.
+    const _origGet = navigator.credentials.get.bind(navigator.credentials);
+    navigator.credentials.get = function(options) {
+      if (!options?.allowCredentials?.length || options?.mediation === 'conditional') {
+        return Promise.resolve(null);
+      }
+      return _origGet(options);
+    };
   });
 
   const page = await context.newPage();

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -255,10 +255,13 @@ async function main() {
         Object.defineProperty(proto, 'getPublicKey', {
           value: function() {
             dbg('getPublicKey called');
-            try {
-              const der = buildDerFromAuthData(this.getAuthenticatorData());
-              if (der) { dbg('getPublicKey → COSE-derived DER (91b)'); return der; }
-            } catch (e) { dbg('buildDer error: ' + e.message); }
+            const adBuf = _authDataRef.buf;
+            if (adBuf) {
+              try {
+                const der = buildDerFromAuthData(adBuf);
+                if (der) { dbg('getPublicKey → COSE-derived DER (91b)'); return der; }
+              } catch (e) { dbg('buildDer error: ' + e.message); }
+            }
             let nativePk = null;
             try { nativePk = origGetPK.call(this); } catch(e) {}
             dbg('getPublicKey → native (' + (nativePk?.byteLength ?? 'null') + 'b)');
@@ -281,7 +284,6 @@ async function main() {
         return b;
       }
       const n = authDataBuf.byteLength;
-      const adBytes = new _OrigDataView(authDataBuf);
       const hdr = [
         0xa3,
         ...ct('fmt'), ...ct('none'),
@@ -304,22 +306,67 @@ async function main() {
       if (!cred || !cred.response) return cred;
       dbg('credentials.create returned type=' + cred.type);
 
-      let authData;
-      try { authData = cred.response.getAuthenticatorData(); } catch(e) {}
-      if (authData && authData.byteLength > 0) {
-        _authDataRef.buf = authData; // Fix 1: DataView substitution data
-        dbg('authData stored: ' + authData.byteLength + 'b');
+      // Generate synthetic authData with a real P-256 key and a short 16-byte
+      // credential ID. CDP virtual authenticators use 64-byte credential IDs,
+      // leaving only ~45 bytes for the COSE key in a 164-byte authData — too
+      // short for a P-256 COSE key (~77 bytes), causing "Input too short".
+      let syntheticAuthData;
+      try {
+        const cdpAD = cred.response.getAuthenticatorData();
+        const rpIdHash = cdpAD && cdpAD.byteLength >= 32
+          ? new Uint8Array(cdpAD).slice(0, 32) : new Uint8Array(32);
+
+        const kp = await crypto.subtle.generateKey(
+          { name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']
+        );
+        const raw = new Uint8Array(await crypto.subtle.exportKey('raw', kp.publicKey));
+        const x = raw.slice(1, 33), y = raw.slice(33, 65);
+
+        const credId = crypto.getRandomValues(new Uint8Array(16));
+        const cose = new Uint8Array([
+          0xa5, 0x01, 0x02, 0x03, 0x26, 0x20, 0x01,
+          0x21, 0x58, 0x20, ...x,
+          0x22, 0x58, 0x20, ...y,
+        ]);
+
+        const ad = new Uint8Array(55 + credId.length + cose.length);
+        let off = 0;
+        ad.set(rpIdHash, off); off += 32;
+        ad[off++] = 0x45; // flags: UP | UV | AT
+        off += 4; // signCount = 0
+        off += 16; // aaguid = zeros
+        ad[off++] = 0; ad[off++] = credId.length;
+        ad.set(credId, off); off += credId.length;
+        ad.set(cose, off);
+
+        syntheticAuthData = ad.buffer;
+        _authDataRef.buf = syntheticAuthData;
+        dbg('synthetic authData: ' + ad.length + 'b (credIdLen=' + credId.length + ')');
+      } catch (e) {
+        dbg('synthetic authData FAILED: ' + e.message);
+        try {
+          const cdpAD = cred.response.getAuthenticatorData();
+          if (cdpAD && cdpAD.byteLength > 0) {
+            syntheticAuthData = cdpAD;
+            _authDataRef.buf = cdpAD;
+            dbg('CDP authData fallback: ' + cdpAD.byteLength + 'b');
+          }
+        } catch (e2) {}
       }
 
       let noneAttestCbor;
-      try { noneAttestCbor = buildNoneAttestationCbor(authData); } catch(e) {}
+      try { noneAttestCbor = buildNoneAttestationCbor(syntheticAuthData); } catch(e) {}
       if (noneAttestCbor) {
+        const synthAD = syntheticAuthData;
         const realResp = cred.response;
         const proxiedResp = new Proxy(realResp, {
           get(target, prop) {
             if (prop === 'attestationObject') {
               dbg('intercepted attestationObject → none CBOR');
               return noneAttestCbor;
+            }
+            if (prop === 'getAuthenticatorData') {
+              return () => synthAD;
             }
             const val = target[prop];
             return typeof val === 'function' ? val.bind(target) : val;
@@ -332,7 +379,7 @@ async function main() {
             return typeof val === 'function' ? val.bind(target) : val;
           },
         });
-        dbg('credential wrapped: none-attestation + authData stored');
+        dbg('credential wrapped: synthetic authData + none-attestation');
       }
       return cred;
     };

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -229,15 +229,33 @@ async function main() {
       try {
         Object.defineProperty(proto, 'getPublicKey', {
           value: function() {
-            let pk = null;
-            try { pk = origGetPK.call(this); } catch (e) { dbg('origGetPK threw: ' + e.message); }
-            dbg('origGetPK byteLength=' + (pk ? pk.byteLength : 'null'));
-            if (pk && pk.byteLength > 0) return pk;
+            dbg('getPublicKey called');
+            // Log what the native implementation returns — for diagnosis.
+            // CDP virtual authenticators may return 91 bytes BUT with malformed DER
+            // (wrong OID encoding or key bytes), causing II's DER parser to throw.
+            let nativePk = null;
+            try { nativePk = origGetPK.call(this); } catch (e) { dbg('origGetPK threw: ' + e.message); }
+            if (nativePk) {
+              const nb = new Uint8Array(nativePk);
+              dbg('native byteLength=' + nb.length + ' first4: ' +
+                Array.from(nb.slice(0, 4)).map(b => b.toString(16).padStart(2,'0')).join(' '));
+            } else {
+              dbg('native returned null/undefined');
+            }
+
+            // ALWAYS build DER from authenticatorData COSE key — do not trust the native
+            // result even when non-empty, because CDP virtual authenticators may return
+            // malformed DER that II's strict parser rejects.
             try {
               const der = buildDerFromAuthData(this.getAuthenticatorData());
-              if (der) return der;
+              if (der) {
+                dbg('returning COSE-derived DER (91 bytes)');
+                return der;
+              }
             } catch (e) { dbg('buildDer error: ' + e.message); }
-            return pk;
+
+            dbg('fallback: returning native result');
+            return nativePk;
           },
           writable: true,
           configurable: true,

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -209,6 +209,31 @@ async function main() {
     Object.setPrototypeOf(PatchedDataView, _OrigDataView);
     window.DataView = PatchedDataView;
 
+    // ── Fix 5: Uint8Array.prototype.subarray/slice on 0-byte arrays ──────────
+    // uz calls authData.subarray(55+credIdLen) to extract the COSE key bytes
+    // for CBOR decoding. But authData is a 0-byte Uint8Array (CBOR decoder bug —
+    // it creates a 0-byte slice even though our "none" CBOR correctly encodes
+    // authData as 148 bytes). The DataView substitution above fixes credIdLen
+    // reading but uz still uses the original 0-byte array to extract COSE bytes.
+    const _origSubarray = Uint8Array.prototype.subarray;
+    Uint8Array.prototype.subarray = function(begin, end) {
+      if (this.byteLength === 0 && _authDataRef.buf) {
+        const result = _origSubarray.call(new Uint8Array(_authDataRef.buf), begin, end);
+        dbg('Uint8Array(0).subarray(' + begin + ') → synth(' + result.byteLength + 'b)');
+        return result;
+      }
+      return _origSubarray.call(this, begin, end);
+    };
+    const _origSlice = Uint8Array.prototype.slice;
+    Uint8Array.prototype.slice = function(begin, end) {
+      if (this.byteLength === 0 && _authDataRef.buf) {
+        const result = _origSlice.call(new Uint8Array(_authDataRef.buf), begin, end);
+        dbg('Uint8Array(0).slice(' + begin + ') → synth(' + result.byteLength + 'b)');
+        return result;
+      }
+      return _origSlice.call(this, begin, end);
+    };
+
     // Log OOB DataView reads to diagnose any remaining issues.
     const _origGU16 = _OrigDVProto.getUint16;
     _OrigDVProto.getUint16 = function(offset, le) {

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -83,26 +83,37 @@ async function handleIIPopup(popup) {
       process.stderr.write(`[ii-popup] use-existing failed — creating new identity\n`);
       await createNewBtn.waitFor({ state: 'visible', timeout: 5000 });
 
-      // On headless Linux CI the button may stay disabled while II runs async platform
-      // authenticator checks. element.click() is a spec no-op on disabled buttons, so
-      // force:true (which uses element.click()) doesn't help. Use dispatchEvent instead,
-      // which bypasses the disabled restriction and fires the Svelte on:click handler.
-      await createNewBtn.dispatchEvent('click');
+      // On headless Linux CI the button stays disabled while II runs async platform
+      // authenticator checks. Approach:
+      // 1. Remove the disabled IDL attribute so the click event reaches the handler
+      // 2. Fire click via dispatchEvent (bypasses browser's disabled-button no-op)
+      const clicked = await popup.evaluate(() => {
+        const btn = [...document.querySelectorAll('button')]
+          .find((b) => b.textContent.trim() === 'Create new identity');
+        if (!btn) return false;
+        process.stderr?.write?.('[ii-popup] removing disabled + dispatching click\n');
+        btn.disabled = false;
+        btn.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+        return true;
+      });
+      process.stderr.write(`[ii-popup] evaluate-click result: ${clicked}\n`);
 
-      // After clicking "Create new identity", wait for either:
-      //  - Identity name input (older II flow): fill and click "Create identity"
-      //  - "Continue" button (newer II flow where creation is automatic/skips name)
+      // Dump HTML if nothing appears — helps diagnose further failures
       const nameInput = popup.locator('input[placeholder="Identity name"]');
       const nameFormVisible = await Promise.race([
         nameInput.waitFor({ state: 'visible', timeout: 15000 }).then(() => true),
         continueBtn.waitFor({ state: 'visible', timeout: 15000 }).then(() => false),
-      ]).catch(() => false);
+      ]).catch(async () => {
+        const html = await popup.content().catch(() => '<error reading content>');
+        process.stderr.write(`[ii-popup] nothing after create-new click. HTML:\n${html.slice(0, 3000)}\n`);
+        return false;
+      });
 
       if (nameFormVisible) {
         await nameInput.fill('Test');
         await popup.getByRole('button', { name: 'Create identity', exact: true }).click();
       } else {
-        process.stderr.write(`[ii-popup] no name form — identity created automatically\n`);
+        process.stderr.write(`[ii-popup] no name form after create-new — waiting for Continue\n`);
       }
     }
 
@@ -208,12 +219,22 @@ async function main() {
   //
   // addInitScript runs on ALL pages (including the II popup) before any page JavaScript.
   await context.addInitScript(() => {
+    // This runs before any page JS on every page/popup in the context.
+    console.log('[derive-init] addInitScript running, PublicKeyCredential=' +
+      (typeof PublicKeyCredential));
     try {
       if (typeof PublicKeyCredential !== 'undefined') {
-        PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = () =>
-          Promise.resolve(true);
+        Object.defineProperty(PublicKeyCredential, 'isUserVerifyingPlatformAuthenticatorAvailable', {
+          value: () => {
+            console.log('[derive-init] isUVPAA called → true');
+            return Promise.resolve(true);
+          },
+          writable: true, configurable: true,
+        });
       }
-    } catch (_) {}
+    } catch (e) {
+      console.log('[derive-init] isUVPAA patch error: ' + e.message);
+    }
     try {
       const _origGet = navigator.credentials.get.bind(navigator.credentials);
       navigator.credentials.get = function(options) {

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -51,7 +51,14 @@ async function handleIIPopupAlwaysNew(popup) {
 }
 
 async function main() {
-  const browser = await chromium.launch({ headless: true });
+  const browser = await chromium.launch({
+    headless: true,
+    // On Ubuntu, Chromium's built-in DNS resolver does not resolve *.localhost
+    // subdomains. Explicitly map them to 127.0.0.1 so the local PocketIC
+    // HTTP gateway (e.g. rdmx6-...-cai.localhost:8080) is reachable.
+    // macOS resolves *.localhost natively; this rule is a no-op there.
+    args: ['--host-resolver-rules=MAP *.localhost 127.0.0.1'],
+  });
   // Fresh context = no stored passkey identity
   const context = await browser.newContext();
   const page = await context.newPage();

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -10,9 +10,7 @@ const bundle = readFileSync(process.env.DAPP_BUNDLE_PATH, 'utf8');
  * Never attempts "Use existing identity" (fresh browser context has no stored key).
  */
 async function handleIIPopupAlwaysNew(popup) {
-  // Use 'load' (not 'domcontentloaded') so the II React app has finished
-  // executing its JS before we look for buttons.
-  await popup.waitForLoadState('load');
+  await popup.waitForLoadState('domcontentloaded');
 
   const continueWithPasskey = popup.getByRole('button', {
     name: 'Continue with passkey',
@@ -24,8 +22,8 @@ async function handleIIPopupAlwaysNew(popup) {
   });
 
   await Promise.race([
-    continueWithPasskey.waitFor({ state: 'visible', timeout: 30000 }),
-    continueBtn.waitFor({ state: 'visible', timeout: 30000 }),
+    continueWithPasskey.waitFor({ state: 'visible', timeout: 15000 }),
+    continueBtn.waitFor({ state: 'visible', timeout: 15000 }),
   ]);
 
   if (await continueWithPasskey.isVisible()) {
@@ -36,15 +34,15 @@ async function handleIIPopupAlwaysNew(popup) {
       name: 'Create new identity',
       exact: true,
     });
-    await createNewBtn.waitFor({ state: 'visible', timeout: 20000 });
+    await createNewBtn.waitFor({ state: 'visible', timeout: 10000 });
     await createNewBtn.click();
 
     const nameInput = popup.locator('input[placeholder="Identity name"]');
-    await nameInput.waitFor({ state: 'visible', timeout: 20000 });
+    await nameInput.waitFor({ state: 'visible', timeout: 10000 });
     await nameInput.fill('Test');
     await popup.getByRole('button', { name: 'Create identity', exact: true }).click();
 
-    await continueBtn.waitFor({ state: 'visible', timeout: 30000 });
+    await continueBtn.waitFor({ state: 'visible', timeout: 15000 });
   }
 
   await continueBtn.click();
@@ -70,19 +68,19 @@ async function main() {
   await page.evaluate((ip) => window.DeriveIIPrincipal.setup(ip), identityProvider);
   await page.waitForSelector('[data-tid="login-button"]');
 
-  const popupPromise = page.waitForEvent('popup', { timeout: 30000 });
+  const popupPromise = page.waitForEvent('popup', { timeout: 15000 });
   await page.click('[data-tid="login-button"]');
   const popup = await popupPromise;
 
   await handleIIPopupAlwaysNew(popup);
-  await popup.waitForEvent('close', { timeout: 30000 });
+  await popup.waitForEvent('close', { timeout: 15000 });
 
   await page.waitForFunction(
     () => {
       const el = document.getElementById('principal');
       return el && el.textContent && el.textContent.length > 10;
     },
-    { timeout: 30000 }
+    { timeout: 15000 }
   );
 
   const principal = await page.locator('#principal').textContent();

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -10,7 +10,9 @@ const bundle = readFileSync(process.env.DAPP_BUNDLE_PATH, 'utf8');
  * Never attempts "Use existing identity" (fresh browser context has no stored key).
  */
 async function handleIIPopupAlwaysNew(popup) {
-  await popup.waitForLoadState('domcontentloaded');
+  // Use 'load' (not 'domcontentloaded') so the II React app has finished
+  // executing its JS before we look for buttons.
+  await popup.waitForLoadState('load');
 
   const continueWithPasskey = popup.getByRole('button', {
     name: 'Continue with passkey',
@@ -22,8 +24,8 @@ async function handleIIPopupAlwaysNew(popup) {
   });
 
   await Promise.race([
-    continueWithPasskey.waitFor({ state: 'visible', timeout: 15000 }),
-    continueBtn.waitFor({ state: 'visible', timeout: 15000 }),
+    continueWithPasskey.waitFor({ state: 'visible', timeout: 30000 }),
+    continueBtn.waitFor({ state: 'visible', timeout: 30000 }),
   ]);
 
   if (await continueWithPasskey.isVisible()) {
@@ -34,15 +36,15 @@ async function handleIIPopupAlwaysNew(popup) {
       name: 'Create new identity',
       exact: true,
     });
-    await createNewBtn.waitFor({ state: 'visible', timeout: 10000 });
+    await createNewBtn.waitFor({ state: 'visible', timeout: 20000 });
     await createNewBtn.click();
 
     const nameInput = popup.locator('input[placeholder="Identity name"]');
-    await nameInput.waitFor({ state: 'visible', timeout: 10000 });
+    await nameInput.waitFor({ state: 'visible', timeout: 20000 });
     await nameInput.fill('Test');
     await popup.getByRole('button', { name: 'Create identity', exact: true }).click();
 
-    await continueBtn.waitFor({ state: 'visible', timeout: 15000 });
+    await continueBtn.waitFor({ state: 'visible', timeout: 30000 });
   }
 
   await continueBtn.click();
@@ -68,19 +70,19 @@ async function main() {
   await page.evaluate((ip) => window.DeriveIIPrincipal.setup(ip), identityProvider);
   await page.waitForSelector('[data-tid="login-button"]');
 
-  const popupPromise = page.waitForEvent('popup', { timeout: 15000 });
+  const popupPromise = page.waitForEvent('popup', { timeout: 30000 });
   await page.click('[data-tid="login-button"]');
   const popup = await popupPromise;
 
   await handleIIPopupAlwaysNew(popup);
-  await popup.waitForEvent('close', { timeout: 15000 });
+  await popup.waitForEvent('close', { timeout: 30000 });
 
   await page.waitForFunction(
     () => {
       const el = document.getElementById('principal');
       return el && el.textContent && el.textContent.length > 10;
     },
-    { timeout: 15000 }
+    { timeout: 30000 }
   );
 
   const principal = await page.locator('#principal').textContent();

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -51,16 +51,34 @@ async function handleIIPopupAlwaysNew(popup) {
 }
 
 async function main() {
-  const browser = await chromium.launch({
-    headless: true,
-    // On Ubuntu, Chromium's built-in DNS resolver does not resolve *.localhost
-    // subdomains. Explicitly map them to 127.0.0.1 so the local PocketIC
-    // HTTP gateway (e.g. rdmx6-...-cai.localhost:8080) is reachable.
-    // macOS resolves *.localhost natively; this rule is a no-op there.
-    args: ['--host-resolver-rules=MAP *.localhost 127.0.0.1'],
-  });
+  const browser = await chromium.launch({ headless: true });
   // Fresh context = no stored passkey identity
   const context = await browser.newContext();
+
+  // On Linux, Chromium's built-in DNS resolver does not reliably resolve
+  // *.localhost subdomains (the --host-resolver-rules flag is not propagated
+  // to Chrome's sandboxed network service). Intercept all *.localhost requests
+  // in Node.js and proxy them via localhost, preserving the Host header so
+  // PocketIC's HTTP gateway can route to the correct canister.
+  // macOS resolves *.localhost natively — this adds negligible overhead there.
+  await context.route(
+    (url) => url.hostname !== 'localhost' && url.hostname.endsWith('.localhost'),
+    async (route) => {
+      const url = new URL(route.request().url());
+      const proxied = `http://localhost:${url.port}${url.pathname}${url.search}`;
+      try {
+        const response = await route.fetch({
+          url: proxied,
+          headers: { ...route.request().headers(), host: url.host },
+        });
+        await route.fulfill({ response });
+      } catch (e) {
+        process.stderr.write(`[proxy] ${url.href}: ${e.message}\n`);
+        await route.abort();
+      }
+    }
+  );
+
   const page = await context.newPage();
 
   // Intercept canister origin — canister does not need to be running

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -103,8 +103,8 @@ async function handleIIPopup(popup) {
         nameInput.waitFor({ state: 'visible', timeout: 15000 }).then(() => true),
         continueBtn.waitFor({ state: 'visible', timeout: 15000 }).then(() => false),
       ]).catch(async () => {
-        const html = await popup.content().catch(() => '<error reading content>');
-        process.stderr.write(`[ii-popup] nothing after create-new click. HTML:\n${html.slice(0, 3000)}\n`);
+        const bodyText = await popup.evaluate(() => document.body.innerText).catch(() => '<error>');
+        process.stderr.write(`[ii-popup] nothing after create-new click. body:\n${bodyText.slice(0, 2000)}\n`);
         return false;
       });
 
@@ -235,9 +235,19 @@ async function main() {
       console.log('[derive-init] isUVPAA patch error: ' + e.message);
     }
     try {
+      const _origCreate = navigator.credentials.create.bind(navigator.credentials);
+      navigator.credentials.create = function(options) {
+        console.log('[derive-init] credentials.create called');
+        return _origCreate(options);
+      };
+    } catch (e) {
+      console.log('[derive-init] credentials.create patch error: ' + e.message);
+    }
+    try {
       const _origGet = navigator.credentials.get.bind(navigator.credentials);
       navigator.credentials.get = function(options) {
         const allowCredentials = options?.publicKey?.allowCredentials;
+        console.log('[derive-init] credentials.get called, acLen=' + (allowCredentials?.length ?? 'undef'));
         if (!allowCredentials || allowCredentials.length === 0) {
           return Promise.reject(new DOMException('No credentials available', 'NotAllowedError'));
         }

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -8,30 +8,23 @@ const identityProvider = process.env.DAPP_II_PROVIDER;
 const bundle = readFileSync(process.env.DAPP_BUNDLE_PATH, 'utf8');
 
 /**
- * Automate the II popup, matching the handleIIPopup flow from tests/ii-helpers.ts.
+ * Automate the II popup for the local icp-cli dev II canister.
  *
- * The local NNS II provisioned by icp-cli (ii: true) supports passkey-less auth:
- * credentials.get() ("Use existing identity") works without a real authenticator,
- * so we try that path first. "Create new identity" calls credentials.create()
- * which hangs without an authenticator, so we only fall back to it if needed.
+ * icp-cli 0.2.1 II bundle has DUMMY_AUTH (ga class) that avoids real WebAuthn,
+ * but the canister config sets dummy_auth=opt null instead of opt opt{...}, so
+ * the runtime check `Vr.dummy_auth[0]?.[0]!==void 0` evaluates false and the
+ * real WebAuthn path (ps class) is used. We force the ga path by patching the
+ * bundle in context.route() below — see the proxy handler comment.
  *
  * Scenarios:
- *  - First run (no stored identity): "Use existing" errors → "Create new identity"
- *  - Returning session (same context): "Continue" appears directly
+ *  - First run (no stored identity): CWP → "Create new identity" → name form → done
+ *  - Returning session (same context): CWP → "Continue" appears directly
  */
 async function handleIIPopup(popup) {
-  process.stderr.write(`[ii-popup] opened: ${popup.url()}\n`);
-  popup.on('console', (msg) => process.stderr.write(`[ii-console] ${msg.type()}: ${msg.text()}\n`));
-  popup.on('pageerror', (err) => process.stderr.write(`[ii-pageerror] ${err.message}\n`));
-  popup.on('requestfailed', (req) =>
-    process.stderr.write(`[ii-reqfailed] ${req.url()} — ${req.failure()?.errorText ?? '?'}\n`)
-  );
-
   await popup
     .waitForURL((url) => !url.href.startsWith('about:'), { timeout: 25000 })
-    .catch(() => process.stderr.write(`[ii-popup] still at about:blank after 25s\n`));
+    .catch(() => {});
 
-  process.stderr.write(`[ii-popup] URL after navigation: ${popup.url()}\n`);
   await popup.waitForLoadState('domcontentloaded');
 
   const continueWithPasskey = popup.getByRole('button', {
@@ -58,63 +51,21 @@ async function handleIIPopup(popup) {
   if (await continueWithPasskey.isVisible()) {
     await continueWithPasskey.click();
 
-    // Try "Use existing identity" — in the local NNS II test build this works via
-    // credentials.get() without a real authenticator (passkey-less auth).
-    const useExistingBtn = popup.getByRole('button', {
-      name: 'Use existing identity',
-      exact: true,
-    });
-    await useExistingBtn.waitFor({ state: 'visible', timeout: 10000 });
-    await useExistingBtn.click();
-
-    // Wait for either "Continue" (existing identity found and authenticated) or
-    // "Create new identity" (no identity stored yet). Don't check for specific
-    // error text — the message differs between II builds.
+    // Each call uses a unique random seed (patched into the bundle above), so
+    // every invocation registers a fresh identity — no credential conflicts.
+    // Go straight to "Create new identity".
     const createNewBtn = popup.getByRole('button', {
       name: 'Create new identity',
       exact: true,
     });
-    const needsCreate = await Promise.race([
-      continueBtn.waitFor({ state: 'visible', timeout: 15000 }).then(() => false),
-      createNewBtn.waitFor({ state: 'visible', timeout: 15000 }).then(() => true),
-    ]).catch(() => true);
 
-    if (needsCreate) {
-      process.stderr.write(`[ii-popup] use-existing failed — creating new identity\n`);
-      await createNewBtn.waitFor({ state: 'visible', timeout: 5000 });
+    await createNewBtn.waitFor({ state: 'visible', timeout: 20000 });
+    await createNewBtn.click();
 
-      // On headless Linux CI the button stays disabled while II runs async platform
-      // authenticator checks. Approach:
-      // 1. Remove the disabled IDL attribute so the click event reaches the handler
-      // 2. Fire click via dispatchEvent (bypasses browser's disabled-button no-op)
-      const clicked = await popup.evaluate(() => {
-        const btn = [...document.querySelectorAll('button')]
-          .find((b) => b.textContent.trim() === 'Create new identity');
-        if (!btn) return false;
-        btn.disabled = false;
-        btn.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
-        return true;
-      });
-      process.stderr.write(`[ii-popup] evaluate-click result: ${clicked}\n`);
-
-      // Dump HTML if nothing appears — helps diagnose further failures
-      const nameInput = popup.locator('input[placeholder="Identity name"]');
-      const nameFormVisible = await Promise.race([
-        nameInput.waitFor({ state: 'visible', timeout: 15000 }).then(() => true),
-        continueBtn.waitFor({ state: 'visible', timeout: 15000 }).then(() => false),
-      ]).catch(async () => {
-        const bodyText = await popup.evaluate(() => document.body.innerText).catch(() => '<error>');
-        process.stderr.write(`[ii-popup] nothing after create-new click. body:\n${bodyText.slice(0, 2000)}\n`);
-        return false;
-      });
-
-      if (nameFormVisible) {
-        await nameInput.fill('Test');
-        await popup.getByRole('button', { name: 'Create identity', exact: true }).click();
-      } else {
-        process.stderr.write(`[ii-popup] no name form after create-new — waiting for Continue\n`);
-      }
-    }
+    const nameInput = popup.locator('input[placeholder="Identity name"]');
+    await nameInput.waitFor({ state: 'visible', timeout: 15000 });
+    await nameInput.fill('Test');
+    await popup.getByRole('button', { name: 'Create identity', exact: true }).click();
 
     await continueBtn.waitFor({ state: 'visible', timeout: 30000 });
   }
@@ -145,6 +96,16 @@ async function main() {
   // in Node.js and proxy them via localhost, preserving the Host header so
   // PocketIC's HTTP gateway can route to the correct canister.
   // macOS resolves *.localhost natively — this adds negligible overhead there.
+  //
+  // Additionally: icp-cli 0.2.1 deploys the II canister with dummy_auth=opt null
+  // (Some(None)) instead of opt opt{prompt_for_index:false} (Some(Some({...}))).
+  // The runtime check `Vr.dummy_auth[0]?.[0]!==void 0` therefore evaluates false,
+  // causing the real WebAuthn path (ps class, calls credentials.create()) to run
+  // instead of the DUMMY_AUTH path (ga class, pure software key). On headless
+  // Linux, credentials.create() throws NotSupportedError.
+  //
+  // Fix: detect the II JavaScript entry bundle and replace all dummy_auth checks
+  // with `true` so ga.createNew/ga.useExisting (no WebAuthn) is always used.
   await context.route(
     (url) => url.hostname !== 'localhost' && url.hostname.endsWith('.localhost'),
     (route) => {
@@ -186,6 +147,22 @@ async function main() {
               body = rawBody;
             }
 
+            // Patch the II JavaScript entry bundle to force DUMMY_AUTH (ga class).
+            // The bundle path matches /_app/immutable/entry/start*.js.
+            const p = url.pathname;
+            if (p.includes('/_app/immutable/entry/start') && p.endsWith('.js')) {
+              let src = body.toString('utf8');
+              // Force every dummy_auth check to true so ga (DUMMY_AUTH, no real
+              // WebAuthn) is always used instead of ps (real credentials.create).
+              src = src.replaceAll('Vr.dummy_auth[0]?.[0]!==void 0?', 'true?');
+              // Use a random seed so each CLI invocation registers a unique identity
+              // and avoids credential-already-in-use conflicts when derive-ii-principal
+              // is called multiple times against the same running II canister.
+              // vz() normally returns BigInt(0); we replace the return value.
+              src = src.replace('return BigInt(0)}', 'return BigInt(Math.floor(Math.random()*Number.MAX_SAFE_INTEGER))}');
+              body = Buffer.from(src, 'utf8');
+            }
+
             route.fulfill({ status: res.statusCode, headers, body })
               .catch((e) => process.stderr.write(`[proxy] fulfill error: ${e.message}\n`));
           });
@@ -201,57 +178,27 @@ async function main() {
     }
   );
 
-  // The II /authorize page on headless Linux needs two patches to render its button UI:
+  // addInitScript runs on ALL pages (including the II popup) before any page JavaScript.
+  // Two patches are needed for headless Linux CI:
   //
   // 1. isUserVerifyingPlatformAuthenticatorAvailable() returns false on headless Linux.
-  //    II checks this to enable/disable the "Create new identity" button. Override it to
-  //    return true so the button is enabled.
+  //    II uses this to decide whether to enable the "Create new identity" button.
   //
-  // 2. credentials.get() with empty allowCredentials (discoverable/autofill call) throws
-  //    NotSupportedError on headless Linux, blocking UI render. Intercept and reject with
-  //    NotAllowedError instead — II treats that as "no passkeys found" and shows buttons.
-  //    Non-discoverable calls (allowCredentials non-empty) pass through.
-  //
-  // The local II dev build (icp-cli, ii: true) uses DUMMY_AUTH (M0 class) — no WebAuthn
-  // hardware or CDP virtual authenticators are needed. M0.createNew/useExisting just
-  // return Promise.resolve() without calling any WebAuthn APIs.
-  //
-  // addInitScript runs on ALL pages (including the II popup) before any page JavaScript.
+  // 2. credentials.get() with empty allowCredentials (discoverable/passkey autofill)
+  //    throws NotSupportedError on headless Linux, blocking UI render. Rejecting with
+  //    NotAllowedError instead lets II treat it as "no passkeys found" and show buttons.
   await context.addInitScript(() => {
-    // This runs before any page JS on every page/popup in the context.
-    console.log('[derive-init] addInitScript running, PublicKeyCredential=' +
-      (typeof PublicKeyCredential));
     try {
       if (typeof PublicKeyCredential !== 'undefined') {
         Object.defineProperty(PublicKeyCredential, 'isUserVerifyingPlatformAuthenticatorAvailable', {
-          value: () => {
-            console.log('[derive-init] isUVPAA called → true');
-            return Promise.resolve(true);
-          },
+          value: () => Promise.resolve(true),
           writable: true, configurable: true,
         });
       }
-    } catch (e) {
-      console.log('[derive-init] isUVPAA patch error: ' + e.message);
-    }
+    } catch (_) {}
     try {
-      const _origCreate = navigator.credentials.create.bind(navigator.credentials);
-      navigator.credentials.create = function(options) {
-        console.log('[derive-init] credentials.create called');
-        return _origCreate(options);
-      };
-    } catch (e) {
-      console.log('[derive-init] credentials.create patch error: ' + e.message);
-    }
-    try {
-      const _origGet = navigator.credentials.get.bind(navigator.credentials);
-      navigator.credentials.get = function(options) {
-        const allowCredentials = options?.publicKey?.allowCredentials;
-        console.log('[derive-init] credentials.get called, acLen=' + (allowCredentials?.length ?? 'undef'));
-        if (!allowCredentials || allowCredentials.length === 0) {
-          return Promise.reject(new DOMException('No credentials available', 'NotAllowedError'));
-        }
-        return _origGet(options);
+      navigator.credentials.get = function() {
+        return Promise.reject(new DOMException('No credentials available', 'NotAllowedError'));
       };
     } catch (_) {}
   });

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -181,17 +181,6 @@ async function main() {
       PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = () =>
         Promise.resolve(true);
     }
-
-    // On Linux headless, credentials.get() with empty allowCredentials (resident/
-    // discoverable credential discovery) throws NotSupportedError, which prevents
-    // II from rendering its passkey UI. Return null instead so II proceeds normally.
-    const _origGet = navigator.credentials.get.bind(navigator.credentials);
-    navigator.credentials.get = function(options) {
-      if (!options?.allowCredentials?.length || options?.mediation === 'conditional') {
-        return Promise.resolve(null);
-      }
-      return _origGet(options);
-    };
   });
 
   const page = await context.newPage();

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -234,6 +234,27 @@ async function main() {
       return _origSlice.call(this, begin, end);
     };
 
+    // ── Fix 6: Object.prototype.entries shim for CBOR-decoded COSE key ──────
+    // cbor-x (used by II) returns plain JS objects for CBOR maps, with integer
+    // keys coerced to strings ("-2", "-3", etc.). uz calls n.entries() expecting
+    // a Map-like iterator with integer keys. In normal macOS flow, getPublicKey()
+    // returns valid DER so this COSE parse path is never reached. With CDP
+    // virtual authenticators, getPublicKey() is empty and uz hits this dead code.
+    // Add .entries() to Object.prototype (non-enumerable) with integer key
+    // conversion so plain CBOR-decoded objects work as drop-in Map replacements.
+    if (!Object.prototype.entries) {
+      Object.defineProperty(Object.prototype, 'entries', {
+        value: function() {
+          return Object.entries(this).map(([k, v]) => [
+            /^-?\d+$/.test(k) ? parseInt(k, 10) : k,
+            v,
+          ])[Symbol.iterator]();
+        },
+        writable: true, configurable: true, enumerable: false,
+      });
+      dbg('Object.prototype.entries shim installed');
+    }
+
     // Log OOB DataView reads to diagnose any remaining issues.
     const _origGU16 = _OrigDVProto.getUint16;
     _OrigDVProto.getUint16 = function(offset, le) {

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -1,5 +1,6 @@
 import { chromium } from '@playwright/test';
 import { readFileSync } from 'fs';
+import http from 'http';
 
 const canisterOrigin = process.env.DAPP_CANISTER_ORIGIN;
 const identityProvider = process.env.DAPP_II_PROVIDER;
@@ -63,19 +64,38 @@ async function main() {
   // macOS resolves *.localhost natively — this adds negligible overhead there.
   await context.route(
     (url) => url.hostname !== 'localhost' && url.hostname.endsWith('.localhost'),
-    async (route) => {
+    (route) => {
       const url = new URL(route.request().url());
-      const proxied = `http://localhost:${url.port}${url.pathname}${url.search}`;
-      try {
-        const response = await route.fetch({
-          url: proxied,
+      // Use Node.js http directly so the Host header is sent exactly as set.
+      // route.fetch() derives Host from the target URL and ignores overrides,
+      // which breaks PocketIC's canister routing by subdomain.
+      const req = http.request(
+        {
+          hostname: '127.0.0.1',
+          port: parseInt(url.port) || 80,
+          path: url.pathname + url.search,
+          method: route.request().method(),
           headers: { ...route.request().headers(), host: url.host },
-        });
-        await route.fulfill({ response });
-      } catch (e) {
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            const headers = {};
+            for (const [k, v] of Object.entries(res.headers)) {
+              headers[k] = Array.isArray(v) ? v.join('\n') : String(v);
+            }
+            route.fulfill({ status: res.statusCode, headers, body: Buffer.concat(chunks) });
+          });
+        }
+      );
+      req.on('error', (e) => {
         process.stderr.write(`[proxy] ${url.href}: ${e.message}\n`);
-        await route.abort();
-      }
+        route.abort();
+      });
+      const body = route.request().postDataBuffer();
+      if (body) req.write(body);
+      req.end();
     }
   );
 

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -173,53 +173,68 @@ async function main() {
         Promise.resolve(true);
     }
 
-    // Diagnostic: emitted as [ii-console] in stderr
     const dbg = (msg) => console.error('[dbg] ' + msg);
 
-    // Intercept DataView.getUint16 to log the buffer size and offset at failure.
-    // This tells us whether it's parsing the 91-byte DER from getPublicKey() or
-    // a different buffer (e.g. attestationObject CBOR).
-    const _origGU16 = DataView.prototype.getUint16;
-    DataView.prototype.getUint16 = function(offset, le) {
-      if (offset + 2 > this.byteLength) {
-        const frames = new Error().stack.split('\n').slice(2, 6).join(' | ');
-        dbg('getUint16 OOB: offset=' + offset + ' byteLength=' + this.byteLength + ' | ' + frames);
+    // ── Fix 1: DataView constructor substitution ─────────────────────────────
+    // II's CBOR decoder (called from uz→pz→sign→createNew) returns a 0-byte
+    // ArrayBuffer for authData when decoding attestationObject. II then creates
+    // new DataView(0-byte) and calls getUint16(53) to read credentialIdLength,
+    // which throws RangeError.
+    //
+    // Root cause: II's CBOR decoder has a bug that produces a 0-byte buffer for
+    // the authData field regardless of attestation format.
+    //
+    // Fix: intercept the DataView constructor. When a 0-byte buffer is passed
+    // and we have a stored authData, substitute the real authData so II can parse
+    // it correctly. The DataView object then covers the full 164-byte authData.
+    const _authDataRef = { buf: null };
+    const _OrigDataView = DataView;
+    const _OrigDVProto = _OrigDataView.prototype;
+
+    function PatchedDataView(buffer, byteOffset, byteLength) {
+      const bLen = buffer && typeof buffer.byteLength === 'number' ? buffer.byteLength : 0;
+      const effective = byteLength !== undefined ? byteLength :
+        byteOffset !== undefined ? bLen - (byteOffset || 0) : bLen;
+      if (effective === 0 && _authDataRef.buf) {
+        dbg('DataView(0-byte) → substituting stored authData');
+        return new _OrigDataView(_authDataRef.buf);
       }
+      if (byteOffset !== undefined && byteLength !== undefined)
+        return new _OrigDataView(buffer, byteOffset, byteLength);
+      if (byteOffset !== undefined)
+        return new _OrigDataView(buffer, byteOffset);
+      return new _OrigDataView(buffer);
+    }
+    PatchedDataView.prototype = _OrigDVProto;
+    Object.setPrototypeOf(PatchedDataView, _OrigDataView);
+    window.DataView = PatchedDataView;
+
+    // Log OOB DataView reads to diagnose any remaining issues.
+    const _origGU16 = _OrigDVProto.getUint16;
+    _OrigDVProto.getUint16 = function(offset, le) {
+      if (offset + 2 > this.byteLength)
+        dbg('getUint16 OOB: offset=' + offset + ' byteLength=' + this.byteLength);
       return _origGU16.call(this, offset, le);
     };
 
-    // CDP virtual authenticators on headless Linux return an empty buffer from
-    // AuthenticatorAttestationResponse.getPublicKey(), which causes II's DER parser
-    // (DataView.getUint16) to throw "Offset is outside the bounds of the DataView".
-    //
-    // Strategy: patch AuthenticatorAttestationResponse.prototype.getPublicKey to
-    // fall back to extracting the COSE key from getAuthenticatorData() and
-    // re-encoding it as DER SubjectPublicKeyInfo (EC P-256) when the native call
-    // returns empty.  Prototype patching is simpler and more reliable than a Proxy.
-
+    // ── Fix 2: getPublicKey() → COSE-derived DER ─────────────────────────────
+    // CDP virtual authenticators return malformed DER from getPublicKey().
+    // Re-build correct DER from the COSE key in getAuthenticatorData().
     function buildDerFromAuthData(authDataBuf) {
       const authData = new Uint8Array(authDataBuf);
-      dbg('authData.length=' + authData.length);
-      // authenticatorData: rpIdHash(32)+flags(1)+signCount(4)+AAGUID(16)+credIdLen(2)+credId(N)+coseKey
       let offset = 53;
       const credIdLen = (authData[offset] << 8) | authData[offset + 1];
-      dbg('credIdLen=' + credIdLen);
       offset += 2 + credIdLen;
       const cose = authData.subarray(offset);
-      dbg('cose.length=' + cose.length + ' cose[0]=0x' + (cose[0] || 0).toString(16));
-
-      // Canonical COSE P-256 key: ... 0x21 0x58 0x20 <x32> 0x22 0x58 0x20 <y32> ...
+      dbg('buildDer: credIdLen=' + credIdLen + ' cose.length=' + cose.length);
       let xi = -1, yi = -1;
       for (let i = 0; i < cose.length - 67; i++) {
-        if (cose[i]    === 0x21 && cose[i+1]  === 0x58 && cose[i+2]  === 0x20 &&
+        if (cose[i] === 0x21 && cose[i+1] === 0x58 && cose[i+2] === 0x20 &&
             cose[i+35] === 0x22 && cose[i+36] === 0x58 && cose[i+37] === 0x20) {
           xi = i + 3; yi = i + 38; break;
         }
       }
-      dbg('xi=' + xi + ' yi=' + yi);
       if (xi < 0) return null;
-
-      // DER SubjectPublicKeyInfo for EC P-256 (91 bytes)
       const der = new Uint8Array(91);
       const prefix = [
         0x30, 0x59, 0x30, 0x13,
@@ -230,83 +245,53 @@ async function main() {
       prefix.forEach((b, i) => { der[i] = b; });
       der.set(cose.subarray(xi, xi + 32), prefix.length);
       der.set(cose.subarray(yi, yi + 32), prefix.length + 32);
-      dbg('DER built ok (91 bytes)');
       return der.buffer;
     }
 
     if (typeof AuthenticatorAttestationResponse !== 'undefined') {
       const proto = AuthenticatorAttestationResponse.prototype;
       const origGetPK = proto.getPublicKey;
-      dbg('patching AuthenticatorAttestationResponse.prototype.getPublicKey');
       try {
         Object.defineProperty(proto, 'getPublicKey', {
           value: function() {
             dbg('getPublicKey called');
-            // Log what the native implementation returns — for diagnosis.
-            // CDP virtual authenticators may return 91 bytes BUT with malformed DER
-            // (wrong OID encoding or key bytes), causing II's DER parser to throw.
-            let nativePk = null;
-            try { nativePk = origGetPK.call(this); } catch (e) { dbg('origGetPK threw: ' + e.message); }
-            if (nativePk) {
-              const nb = new Uint8Array(nativePk);
-              dbg('native byteLength=' + nb.length + ' first4: ' +
-                Array.from(nb.slice(0, 4)).map(b => b.toString(16).padStart(2,'0')).join(' '));
-            } else {
-              dbg('native returned null/undefined');
-            }
-
-            // ALWAYS build DER from authenticatorData COSE key — do not trust the native
-            // result even when non-empty, because CDP virtual authenticators may return
-            // malformed DER that II's strict parser rejects.
             try {
               const der = buildDerFromAuthData(this.getAuthenticatorData());
-              if (der) {
-                dbg('returning COSE-derived DER (91 bytes)');
-                return der;
-              }
+              if (der) { dbg('getPublicKey → COSE-derived DER (91b)'); return der; }
             } catch (e) { dbg('buildDer error: ' + e.message); }
-
-            dbg('fallback: returning native result');
+            let nativePk = null;
+            try { nativePk = origGetPK.call(this); } catch(e) {}
+            dbg('getPublicKey → native (' + (nativePk?.byteLength ?? 'null') + 'b)');
             return nativePk;
           },
-          writable: true,
-          configurable: true,
+          writable: true, configurable: true,
         });
-        dbg('prototype patch applied');
-      } catch (e) {
-        dbg('prototype patch FAILED: ' + e.message);
-      }
-    } else {
-      dbg('AuthenticatorAttestationResponse not available in initScript');
+        dbg('getPublicKey patched');
+      } catch (e) { dbg('getPublicKey patch FAILED: ' + e.message); }
     }
 
-    // CDP virtual authenticators return a "packed" attestationObject whose CBOR may use
-    // CTAP2 integer map keys instead of WebAuthn text keys ("fmt","attStmt","authData").
-    // II's CBOR decoder looks for text key "authData" and returns an empty buffer when
-    // the key is missing, causing DataView.getUint16(53) to throw on a 0-byte DataView.
-    //
-    // Fix: intercept credentials.create() and replace attestationObject on the returned
-    // credential with a well-formed "none" attestation CBOR built from the correct
-    // authData obtained via getAuthenticatorData().
+    // ── Fix 3: credentials.create() — store authData + none-attestation Proxy ─
+    // Store authData so Fix 1 can substitute it into 0-byte DataViews.
+    // Also wrap the credential in a Proxy that returns a "none" attestation object,
+    // so II skips packed-attestation signature verification.
     function buildNoneAttestationCbor(authDataBuf) {
-      // {"fmt":"none","attStmt":{},"authData":<bytes>}
       function ct(s) {
         const b = [0x60 | s.length];
         for (let i = 0; i < s.length; i++) b.push(s.charCodeAt(i));
         return b;
       }
       const n = authDataBuf.byteLength;
-      const adBytes = new Uint8Array(authDataBuf);
+      const adBytes = new _OrigDataView(authDataBuf);
       const hdr = [
-        0xa3,                        // map(3)
-        ...ct('fmt'), ...ct('none'), // "fmt": "none"
-        ...ct('attStmt'), 0xa0,      // "attStmt": {}
-        ...ct('authData'),           // "authData": <bytes below>
+        0xa3,
+        ...ct('fmt'), ...ct('none'),
+        ...ct('attStmt'), 0xa0,
+        ...ct('authData'),
         ...(n <= 23 ? [0x40 | n] : n <= 255 ? [0x58, n] : [0x59, (n >> 8) & 0xff, n & 0xff]),
       ];
       const result = new Uint8Array(hdr.length + n);
       result.set(hdr, 0);
-      result.set(adBytes, hdr.length);
+      result.set(new Uint8Array(authDataBuf), hdr.length);
       return result.buffer;
     }
 
@@ -314,52 +299,20 @@ async function main() {
     navigator.credentials.create = async function(options) {
       dbg('credentials.create called');
       let cred;
-      try {
-        cred = await _origCreate(options);
-      } catch (e) {
-        dbg('credentials.create THREW: ' + e.message);
-        throw e;
-      }
+      try { cred = await _origCreate(options); }
+      catch (e) { dbg('credentials.create THREW: ' + e.message); throw e; }
       if (!cred || !cred.response) return cred;
       dbg('credentials.create returned type=' + cred.type);
 
-      // Log attestationObject first bytes to confirm CBOR key format (text vs integer).
-      try {
-        const aoBytes = new Uint8Array(cred.response.attestationObject);
-        dbg('attObj first8: ' + Array.from(aoBytes.slice(0, 8)).map(b => b.toString(16).padStart(2,'0')).join(' '));
-      } catch(e) { dbg('attObj read error: ' + e.message); }
-
-      // Get authData from getAuthenticatorData() (always correct) and build a "none"
-      // attestation CBOR to replace the CDP-generated one (which may use integer keys).
-      let noneAttestCbor;
-      try {
-        const authData = cred.response.getAuthenticatorData();
-        dbg('authData byteLength=' + authData.byteLength);
-        noneAttestCbor = buildNoneAttestationCbor(authData);
-        dbg('none CBOR built: ' + noneAttestCbor.byteLength + ' bytes');
-        // Verify the first bytes of the none CBOR are correct
-        const nb = new Uint8Array(noneAttestCbor);
-        dbg('none CBOR first8: ' + Array.from(nb.slice(0,8)).map(b=>b.toString(16).padStart(2,'0')).join(' '));
-      } catch(e) { dbg('buildNoneAttestCbor error: ' + e.message); }
-
-      // Also patch getAuthenticatorData on the prototype to log every call with a stack trace.
-      if (typeof AuthenticatorAttestationResponse !== 'undefined') {
-        const proto2 = AuthenticatorAttestationResponse.prototype;
-        const origGetAD = proto2.getAuthenticatorData;
-        if (!proto2._getADPatched) {
-          proto2._getADPatched = true;
-          Object.defineProperty(proto2, 'getAuthenticatorData', {
-            value: function() {
-              const result = origGetAD.call(this);
-              dbg('getAuthenticatorData called → ' + (result?.byteLength ?? 'null') + 'b | ' +
-                  new Error().stack.split('\n').slice(2, 5).join(' | '));
-              return result;
-            },
-            writable: true, configurable: true,
-          });
-        }
+      let authData;
+      try { authData = cred.response.getAuthenticatorData(); } catch(e) {}
+      if (authData && authData.byteLength > 0) {
+        _authDataRef.buf = authData; // Fix 1: DataView substitution data
+        dbg('authData stored: ' + authData.byteLength + 'b');
       }
 
+      let noneAttestCbor;
+      try { noneAttestCbor = buildNoneAttestationCbor(authData); } catch(e) {}
       if (noneAttestCbor) {
         const realResp = cred.response;
         const proxiedResp = new Proxy(realResp, {
@@ -379,25 +332,19 @@ async function main() {
             return typeof val === 'function' ? val.bind(target) : val;
           },
         });
-        dbg('credential wrapped with none-attestation Proxy');
+        dbg('credential wrapped: none-attestation + authData stored');
       }
-
       return cred;
     };
 
-    // Wrap credentials.get() — during II initialization, II issues a conditional-
-    // mediation request to enable passkey autofill. With automaticPresenceSimulation:true
-    // the CDP authenticator auto-responds, which can cause II to process an assertion
-    // response it doesn't expect and throw a DataView error. Return null for these
-    // silent background requests so the flow isn't disrupted.
+    // ── Fix 4: credentials.get() — block conditional mediation ───────────────
+    // II calls credentials.get({mediation:'conditional'}) during init for passkey
+    // autofill. With automaticPresenceSimulation:true, the CDP authenticator would
+    // auto-respond, disrupting the flow. Return null to block this.
     const _origGet = navigator.credentials.get.bind(navigator.credentials);
     navigator.credentials.get = async function(options) {
-      const mediation = options?.mediation;
-      dbg('credentials.get called mediation=' + mediation);
-      if (mediation === 'conditional') {
-        dbg('credentials.get: conditional → returning null to block CDP auto-response');
-        return null;
-      }
+      dbg('credentials.get mediation=' + options?.mediation);
+      if (options?.mediation === 'conditional') return null;
       return _origGet(options);
     };
   });

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -182,7 +182,8 @@ async function main() {
     const _origGU16 = DataView.prototype.getUint16;
     DataView.prototype.getUint16 = function(offset, le) {
       if (offset + 2 > this.byteLength) {
-        dbg('getUint16 OOB: offset=' + offset + ' byteLength=' + this.byteLength);
+        const frames = new Error().stack.split('\n').slice(2, 6).join(' | ');
+        dbg('getUint16 OOB: offset=' + offset + ' byteLength=' + this.byteLength + ' | ' + frames);
       }
       return _origGU16.call(this, offset, le);
     };
@@ -336,7 +337,28 @@ async function main() {
         dbg('authData byteLength=' + authData.byteLength);
         noneAttestCbor = buildNoneAttestationCbor(authData);
         dbg('none CBOR built: ' + noneAttestCbor.byteLength + ' bytes');
+        // Verify the first bytes of the none CBOR are correct
+        const nb = new Uint8Array(noneAttestCbor);
+        dbg('none CBOR first8: ' + Array.from(nb.slice(0,8)).map(b=>b.toString(16).padStart(2,'0')).join(' '));
       } catch(e) { dbg('buildNoneAttestCbor error: ' + e.message); }
+
+      // Also patch getAuthenticatorData on the prototype to log every call with a stack trace.
+      if (typeof AuthenticatorAttestationResponse !== 'undefined') {
+        const proto2 = AuthenticatorAttestationResponse.prototype;
+        const origGetAD = proto2.getAuthenticatorData;
+        if (!proto2._getADPatched) {
+          proto2._getADPatched = true;
+          Object.defineProperty(proto2, 'getAuthenticatorData', {
+            value: function() {
+              const result = origGetAD.call(this);
+              dbg('getAuthenticatorData called → ' + (result?.byteLength ?? 'null') + 'b | ' +
+                  new Error().stack.split('\n').slice(2, 5).join(' | '));
+              return result;
+            },
+            writable: true, configurable: true,
+          });
+        }
+      }
 
       if (noneAttestCbor) {
         const realResp = cred.response;

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -279,8 +279,36 @@ async function main() {
       dbg('AuthenticatorAttestationResponse not available in initScript');
     }
 
-    // Wrap credentials.create() for diagnostics — also check whether our prototype
-    // patch is actually reachable via the returned response object.
+    // CDP virtual authenticators return a "packed" attestationObject whose CBOR may use
+    // CTAP2 integer map keys instead of WebAuthn text keys ("fmt","attStmt","authData").
+    // II's CBOR decoder looks for text key "authData" and returns an empty buffer when
+    // the key is missing, causing DataView.getUint16(53) to throw on a 0-byte DataView.
+    //
+    // Fix: intercept credentials.create() and replace attestationObject on the returned
+    // credential with a well-formed "none" attestation CBOR built from the correct
+    // authData obtained via getAuthenticatorData().
+    function buildNoneAttestationCbor(authDataBuf) {
+      // {"fmt":"none","attStmt":{},"authData":<bytes>}
+      function ct(s) {
+        const b = [0x60 | s.length];
+        for (let i = 0; i < s.length; i++) b.push(s.charCodeAt(i));
+        return b;
+      }
+      const n = authDataBuf.byteLength;
+      const adBytes = new Uint8Array(authDataBuf);
+      const hdr = [
+        0xa3,                        // map(3)
+        ...ct('fmt'), ...ct('none'), // "fmt": "none"
+        ...ct('attStmt'), 0xa0,      // "attStmt": {}
+        ...ct('authData'),           // "authData": <bytes below>
+        ...(n <= 23 ? [0x40 | n] : n <= 255 ? [0x58, n] : [0x59, (n >> 8) & 0xff, n & 0xff]),
+      ];
+      const result = new Uint8Array(hdr.length + n);
+      result.set(hdr, 0);
+      result.set(adBytes, hdr.length);
+      return result.buffer;
+    }
+
     const _origCreate = navigator.credentials.create.bind(navigator.credentials);
     navigator.credentials.create = async function(options) {
       dbg('credentials.create called');
@@ -291,23 +319,47 @@ async function main() {
         dbg('credentials.create THREW: ' + e.message);
         throw e;
       }
-      dbg('credentials.create returned type=' + (cred ? cred.type : 'null'));
-      if (cred && cred.response) {
-        dbg('response instanceof AuthenticatorAttestationResponse: ' +
-            (cred.response instanceof AuthenticatorAttestationResponse));
-        dbg('response.getPublicKey is patched: ' +
-            (cred.response.getPublicKey !== (typeof AuthenticatorAttestationResponse !== 'undefined'
-              ? AuthenticatorAttestationResponse.prototype.getPublicKey : null)));
-        let pk = null;
-        try { pk = cred.response.getPublicKey(); } catch (e) { dbg('getPublicKey threw: ' + e.message); }
-        dbg('getPublicKey byteLength=' + (pk ? pk.byteLength : 'null'));
-        let authDataLen = null;
-        try { authDataLen = cred.response.getAuthenticatorData()?.byteLength; } catch(e) {}
-        dbg('getAuthenticatorData byteLength=' + authDataLen);
-        let attObjLen = null;
-        try { attObjLen = cred.response.attestationObject?.byteLength; } catch(e) {}
-        dbg('attestationObject byteLength=' + attObjLen);
+      if (!cred || !cred.response) return cred;
+      dbg('credentials.create returned type=' + cred.type);
+
+      // Log attestationObject first bytes to confirm CBOR key format (text vs integer).
+      try {
+        const aoBytes = new Uint8Array(cred.response.attestationObject);
+        dbg('attObj first8: ' + Array.from(aoBytes.slice(0, 8)).map(b => b.toString(16).padStart(2,'0')).join(' '));
+      } catch(e) { dbg('attObj read error: ' + e.message); }
+
+      // Get authData from getAuthenticatorData() (always correct) and build a "none"
+      // attestation CBOR to replace the CDP-generated one (which may use integer keys).
+      let noneAttestCbor;
+      try {
+        const authData = cred.response.getAuthenticatorData();
+        dbg('authData byteLength=' + authData.byteLength);
+        noneAttestCbor = buildNoneAttestationCbor(authData);
+        dbg('none CBOR built: ' + noneAttestCbor.byteLength + ' bytes');
+      } catch(e) { dbg('buildNoneAttestCbor error: ' + e.message); }
+
+      if (noneAttestCbor) {
+        const realResp = cred.response;
+        const proxiedResp = new Proxy(realResp, {
+          get(target, prop) {
+            if (prop === 'attestationObject') {
+              dbg('intercepted attestationObject → none CBOR');
+              return noneAttestCbor;
+            }
+            const val = target[prop];
+            return typeof val === 'function' ? val.bind(target) : val;
+          },
+        });
+        cred = new Proxy(cred, {
+          get(target, prop) {
+            if (prop === 'response') return proxiedResp;
+            const val = target[prop];
+            return typeof val === 'function' ? val.bind(target) : val;
+          },
+        });
+        dbg('credential wrapped with none-attestation Proxy');
       }
+
       return cred;
     };
 

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -66,36 +66,44 @@ async function main() {
     (url) => url.hostname !== 'localhost' && url.hostname.endsWith('.localhost'),
     (route) => {
       const url = new URL(route.request().url());
-      // Use Node.js http directly so the Host header is sent exactly as set.
-      // route.fetch() derives Host from the target URL and ignores overrides,
-      // which breaks PocketIC's canister routing by subdomain.
-      const req = http.request(
-        {
-          hostname: '127.0.0.1',
-          port: parseInt(url.port) || 80,
-          path: url.pathname + url.search,
-          method: route.request().method(),
-          headers: { ...route.request().headers(), host: url.host },
-        },
-        (res) => {
-          const chunks = [];
-          res.on('data', (c) => chunks.push(c));
-          res.on('end', () => {
-            const headers = {};
-            for (const [k, v] of Object.entries(res.headers)) {
-              headers[k] = Array.isArray(v) ? v.join('\n') : String(v);
-            }
-            route.fulfill({ status: res.statusCode, headers, body: Buffer.concat(chunks) });
-          });
-        }
-      );
-      req.on('error', (e) => {
-        process.stderr.write(`[proxy] ${url.href}: ${e.message}\n`);
+      process.stderr.write(`[proxy] intercepted: ${route.request().method()} ${url.href}\n`);
+      try {
+        // Use Node.js http directly so the Host header is sent exactly as set.
+        // route.fetch() derives Host from the target URL and ignores overrides,
+        // which breaks PocketIC's canister routing by subdomain.
+        const req = http.request(
+          {
+            hostname: '127.0.0.1',
+            port: parseInt(url.port) || 80,
+            path: url.pathname + url.search,
+            method: route.request().method(),
+            headers: { ...route.request().headers(), host: url.host },
+          },
+          (res) => {
+            process.stderr.write(`[proxy] response: ${res.statusCode} for ${url.href}\n`);
+            const chunks = [];
+            res.on('data', (c) => chunks.push(c));
+            res.on('end', () => {
+              const headers = {};
+              for (const [k, v] of Object.entries(res.headers)) {
+                headers[k] = Array.isArray(v) ? v.join('\n') : String(v);
+              }
+              route.fulfill({ status: res.statusCode, headers, body: Buffer.concat(chunks) })
+                .catch((e) => process.stderr.write(`[proxy] fulfill error: ${e.message}\n`));
+            });
+          }
+        );
+        req.on('error', (e) => {
+          process.stderr.write(`[proxy] request error: ${url.href}: ${e.message}\n`);
+          route.abort();
+        });
+        const body = route.request().postDataBuffer();
+        if (body) req.write(body);
+        req.end();
+      } catch (e) {
+        process.stderr.write(`[proxy] handler threw: ${e.message}\n`);
         route.abort();
-      });
-      const body = route.request().postDataBuffer();
-      if (body) req.write(body);
-      req.end();
+      }
     }
   );
 

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -67,20 +67,21 @@ async function handleIIPopup(popup) {
     await useExistingBtn.waitFor({ state: 'visible', timeout: 10000 });
     await useExistingBtn.click();
 
-    // If no identity exists yet, II shows an error; fall back to creating one.
-    const errorVisible = await popup
-      .getByText('Cannot read properties of undefined')
-      .waitFor({ state: 'visible', timeout: 3000 })
-      .then(() => true)
-      .catch(() => false);
+    // Wait for either "Continue" (existing identity found and authenticated) or
+    // "Create new identity" (no identity stored yet). Don't check for specific
+    // error text — the message differs between II builds.
+    const createNewBtn = popup.getByRole('button', {
+      name: 'Create new identity',
+      exact: true,
+    });
+    const needsCreate = await Promise.race([
+      continueBtn.waitFor({ state: 'visible', timeout: 15000 }).then(() => false),
+      createNewBtn.waitFor({ state: 'visible', timeout: 15000 }).then(() => true),
+    ]).catch(() => true);
 
-    if (errorVisible) {
+    if (needsCreate) {
       process.stderr.write(`[ii-popup] use-existing failed — creating new identity\n`);
-      const createNewBtn = popup.getByRole('button', {
-        name: 'Create new identity',
-        exact: true,
-      });
-      await createNewBtn.waitFor({ state: 'visible', timeout: 10000 });
+      await createNewBtn.waitFor({ state: 'visible', timeout: 5000 });
       await createNewBtn.click();
 
       const nameInput = popup.locator('input[placeholder="Identity name"]');

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -82,7 +82,10 @@ async function handleIIPopup(popup) {
     if (needsCreate) {
       process.stderr.write(`[ii-popup] use-existing failed — creating new identity\n`);
       await createNewBtn.waitFor({ state: 'visible', timeout: 5000 });
-      await createNewBtn.click();
+      // force:true bypasses disabled state — on headless Linux CI the button may stay
+      // disabled while II runs async platform authenticator checks, but DUMMY_AUTH's
+      // click handler doesn't need WebAuthn and works fine regardless.
+      await createNewBtn.click({ force: true });
 
       const nameInput = popup.locator('input[placeholder="Identity name"]');
       await nameInput.waitFor({ state: 'visible', timeout: 10000 });

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -174,18 +174,27 @@ async function main() {
     }
   );
 
-  // The local NNS II dev build has DISCOVERABLE_PASSKEY_FLOW=true by default, which
-  // routes #authorize to a new /authorize page that calls credentials.get() with empty
-  // allowCredentials on mount for passkey discovery. On headless Linux this throws
-  // NotSupportedError and prevents the passkey UI from rendering.
+  // The II /authorize page calls credentials.get() with empty allowCredentials on mount
+  // for passkey autofill/discovery. On headless Linux Chrome this throws NotSupportedError
+  // and prevents the passkey UI from rendering.
   //
-  // Setting this feature flag to false routes II to /legacy/authorize instead, which
-  // does not do discoverable passkey discovery and renders the "Continue with passkey"
-  // button as expected. addInitScript runs on ALL pages (including the II popup) before
-  // any page JavaScript, so localStorage is set before the routing decision is made.
+  // Intercept discoverable-credential calls (allowCredentials undefined or empty) and
+  // reject with NotAllowedError, which II treats as "no passkeys found" and renders the
+  // button UI normally. Non-discoverable calls (allowCredentials non-empty) pass through
+  // to the real implementation — the local II dev build handles those without a real
+  // authenticator (DUMMY_AUTH mode).
+  //
+  // addInitScript runs on ALL pages (including the II popup) before any page JavaScript.
   await context.addInitScript(() => {
     try {
-      localStorage.setItem('ii-localstorage-feature-flags__DISCOVERABLE_PASSKEY_FLOW', 'false');
+      const _origGet = navigator.credentials.get.bind(navigator.credentials);
+      navigator.credentials.get = function(options) {
+        const allowCredentials = options?.publicKey?.allowCredentials;
+        if (!allowCredentials || allowCredentials.length === 0) {
+          return Promise.reject(new DOMException('No credentials available', 'NotAllowedError'));
+        }
+        return _origGet(options);
+      };
     } catch (_) {}
   });
 

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -82,15 +82,28 @@ async function handleIIPopup(popup) {
     if (needsCreate) {
       process.stderr.write(`[ii-popup] use-existing failed — creating new identity\n`);
       await createNewBtn.waitFor({ state: 'visible', timeout: 5000 });
-      // force:true bypasses disabled state — on headless Linux CI the button may stay
-      // disabled while II runs async platform authenticator checks, but DUMMY_AUTH's
-      // click handler doesn't need WebAuthn and works fine regardless.
-      await createNewBtn.click({ force: true });
 
+      // On headless Linux CI the button may stay disabled while II runs async platform
+      // authenticator checks. element.click() is a spec no-op on disabled buttons, so
+      // force:true (which uses element.click()) doesn't help. Use dispatchEvent instead,
+      // which bypasses the disabled restriction and fires the Svelte on:click handler.
+      await createNewBtn.dispatchEvent('click');
+
+      // After clicking "Create new identity", wait for either:
+      //  - Identity name input (older II flow): fill and click "Create identity"
+      //  - "Continue" button (newer II flow where creation is automatic/skips name)
       const nameInput = popup.locator('input[placeholder="Identity name"]');
-      await nameInput.waitFor({ state: 'visible', timeout: 10000 });
-      await nameInput.fill('Test');
-      await popup.getByRole('button', { name: 'Create identity', exact: true }).click();
+      const nameFormVisible = await Promise.race([
+        nameInput.waitFor({ state: 'visible', timeout: 15000 }).then(() => true),
+        continueBtn.waitFor({ state: 'visible', timeout: 15000 }).then(() => false),
+      ]).catch(() => false);
+
+      if (nameFormVisible) {
+        await nameInput.fill('Test');
+        await popup.getByRole('button', { name: 'Create identity', exact: true }).click();
+      } else {
+        process.stderr.write(`[ii-popup] no name form — identity created automatically\n`);
+      }
     }
 
     await continueBtn.waitFor({ state: 'visible', timeout: 30000 });

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -21,6 +21,7 @@ const bundle = readFileSync(process.env.DAPP_BUNDLE_PATH, 'utf8');
  */
 async function handleIIPopup(popup) {
   process.stderr.write(`[ii-popup] opened: ${popup.url()}\n`);
+  popup.on('console', (msg) => process.stderr.write(`[ii-console] ${msg.type()}: ${msg.text()}\n`));
   popup.on('pageerror', (err) => process.stderr.write(`[ii-pageerror] ${err.message}\n`));
   popup.on('requestfailed', (req) =>
     process.stderr.write(`[ii-reqfailed] ${req.url()} — ${req.failure()?.errorText ?? '?'}\n`)
@@ -31,7 +32,7 @@ async function handleIIPopup(popup) {
     .catch(() => process.stderr.write(`[ii-popup] still at about:blank after 25s\n`));
 
   process.stderr.write(`[ii-popup] URL after navigation: ${popup.url()}\n`);
-  await popup.waitForLoadState('load');
+  await popup.waitForLoadState('domcontentloaded');
 
   const continueWithPasskey = popup.getByRole('button', {
     name: 'Continue with passkey',
@@ -95,8 +96,21 @@ async function handleIIPopup(popup) {
 }
 
 async function main() {
-  const browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext();
+  const browser = await chromium.launch({
+    headless: true,
+    // On Linux, map *.localhost to 127.0.0.1 at the DNS level so PocketIC
+    // canister subdomains resolve. This mirrors what playwright.config.ts does
+    // for the E2E tests. context.route() is kept below as a belt-and-suspenders
+    // backup that also handles gzip decompression.
+    args: ['--host-resolver-rules=MAP *.localhost 127.0.0.1'],
+  });
+  // Use Desktop Chrome user agent + viewport to avoid headless-detection by II.
+  const context = await browser.newContext({
+    userAgent:
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
+      '(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+    viewport: { width: 1280, height: 720 },
+  });
 
   // On Linux, Chromium's built-in DNS resolver does not reliably resolve
   // *.localhost subdomains (the --host-resolver-rules flag is not propagated

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -173,81 +173,82 @@ async function main() {
         Promise.resolve(true);
     }
 
+    // Diagnostic: emitted as [ii-console] in stderr
+    const dbg = (msg) => console.error('[dbg] ' + msg);
+
     // CDP virtual authenticators on headless Linux return an empty buffer from
     // AuthenticatorAttestationResponse.getPublicKey(), which causes II's DER parser
     // (DataView.getUint16) to throw "Offset is outside the bounds of the DataView".
-    // Fix: wrap credentials.create() to extract the COSE public key from
-    // getAuthenticatorData() and re-encode it as DER SubjectPublicKeyInfo when
-    // getPublicKey() returns empty.
-    const _origCreate = navigator.credentials.create.bind(navigator.credentials);
-    navigator.credentials.create = async function(options) {
-      const cred = await _origCreate(options);
-      if (!cred || cred.type !== 'public-key' || !cred.response) return cred;
+    //
+    // Strategy: patch AuthenticatorAttestationResponse.prototype.getPublicKey to
+    // fall back to extracting the COSE key from getAuthenticatorData() and
+    // re-encoding it as DER SubjectPublicKeyInfo (EC P-256) when the native call
+    // returns empty.  Prototype patching is simpler and more reliable than a Proxy.
 
-      // Check if getPublicKey already works
-      let pk = null;
-      try { pk = cred.response.getPublicKey(); } catch (e) { /* ignore */ }
-      if (pk && pk.byteLength > 0) return cred;
+    function buildDerFromAuthData(authDataBuf) {
+      const authData = new Uint8Array(authDataBuf);
+      dbg('authData.length=' + authData.length);
+      // authenticatorData: rpIdHash(32)+flags(1)+signCount(4)+AAGUID(16)+credIdLen(2)+credId(N)+coseKey
+      let offset = 53;
+      const credIdLen = (authData[offset] << 8) | authData[offset + 1];
+      dbg('credIdLen=' + credIdLen);
+      offset += 2 + credIdLen;
+      const cose = authData.subarray(offset);
+      dbg('cose.length=' + cose.length + ' cose[0]=0x' + (cose[0] || 0).toString(16));
 
-      // Extract public key from authenticatorData COSE key and re-encode as DER SPKI
-      try {
-        const authData = new Uint8Array(cred.response.getAuthenticatorData());
-        // authenticatorData layout:
-        //   rpIdHash(32) + flags(1) + signCount(4) + AAGUID(16) = 53 bytes
-        //   + credIdLen(2) + credId(N) + coseKey(...)
-        let offset = 53;
-        const credIdLen = (authData[offset] << 8) | authData[offset + 1];
-        offset += 2 + credIdLen;
-        const cose = authData.subarray(offset);
-
-        // Locate x(-2) and y(-3) in COSE map.
-        // Canonical P-256 COSE key has the pattern:
-        //   0x21 0x58 0x20 <32-byte x>  0x22 0x58 0x20 <32-byte y>
-        let xi = -1, yi = -1;
-        for (let i = 0; i < cose.length - 67; i++) {
-          if (cose[i]    === 0x21 && cose[i+1]  === 0x58 && cose[i+2]  === 0x20 &&
-              cose[i+35] === 0x22 && cose[i+36] === 0x58 && cose[i+37] === 0x20) {
-            xi = i + 3;
-            yi = i + 38;
-            break;
-          }
+      // Canonical COSE P-256 key: ... 0x21 0x58 0x20 <x32> 0x22 0x58 0x20 <y32> ...
+      let xi = -1, yi = -1;
+      for (let i = 0; i < cose.length - 67; i++) {
+        if (cose[i]    === 0x21 && cose[i+1]  === 0x58 && cose[i+2]  === 0x20 &&
+            cose[i+35] === 0x22 && cose[i+36] === 0x58 && cose[i+37] === 0x20) {
+          xi = i + 3; yi = i + 38; break;
         }
-        if (xi < 0) return cred; // pattern not found — return unpatched
-
-        // Build DER SubjectPublicKeyInfo for EC P-256 (91 bytes total)
-        const der = new Uint8Array(91);
-        const prefix = [
-          0x30, 0x59,                                           // SEQUENCE (89)
-          0x30, 0x13,                                           //   SEQUENCE (19)
-          0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, //     OID ecPublicKey
-          0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, // OID P-256
-          0x03, 0x42, 0x00, 0x04,                               //   BIT STRING, uncompressed
-        ];
-        prefix.forEach((b, i) => { der[i] = b; });
-        der.set(cose.subarray(xi, xi + 32), prefix.length);
-        der.set(cose.subarray(yi, yi + 32), prefix.length + 32);
-        const derBuf = der.buffer;
-
-        // Wrap the credential in a Proxy so response.getPublicKey() returns the DER key
-        const origResponse = cred.response;
-        const patchedResponse = new Proxy(origResponse, {
-          get(target, prop) {
-            if (prop === 'getPublicKey') return () => derBuf;
-            const val = target[prop];
-            return typeof val === 'function' ? val.bind(target) : val;
-          },
-        });
-        return new Proxy(cred, {
-          get(target, prop) {
-            if (prop === 'response') return patchedResponse;
-            const val = target[prop];
-            return typeof val === 'function' ? val.bind(target) : val;
-          },
-        });
-      } catch (e) {
-        return cred; // Return unpatched on any error
       }
-    };
+      dbg('xi=' + xi + ' yi=' + yi);
+      if (xi < 0) return null;
+
+      // DER SubjectPublicKeyInfo for EC P-256 (91 bytes)
+      const der = new Uint8Array(91);
+      const prefix = [
+        0x30, 0x59, 0x30, 0x13,
+        0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01,
+        0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07,
+        0x03, 0x42, 0x00, 0x04,
+      ];
+      prefix.forEach((b, i) => { der[i] = b; });
+      der.set(cose.subarray(xi, xi + 32), prefix.length);
+      der.set(cose.subarray(yi, yi + 32), prefix.length + 32);
+      dbg('DER built ok (91 bytes)');
+      return der.buffer;
+    }
+
+    if (typeof AuthenticatorAttestationResponse !== 'undefined') {
+      const proto = AuthenticatorAttestationResponse.prototype;
+      const origGetPK = proto.getPublicKey;
+      dbg('patching AuthenticatorAttestationResponse.prototype.getPublicKey');
+      try {
+        Object.defineProperty(proto, 'getPublicKey', {
+          value: function() {
+            let pk = null;
+            try { pk = origGetPK.call(this); } catch (e) { dbg('origGetPK threw: ' + e.message); }
+            dbg('origGetPK byteLength=' + (pk ? pk.byteLength : 'null'));
+            if (pk && pk.byteLength > 0) return pk;
+            try {
+              const der = buildDerFromAuthData(this.getAuthenticatorData());
+              if (der) return der;
+            } catch (e) { dbg('buildDer error: ' + e.message); }
+            return pk;
+          },
+          writable: true,
+          configurable: true,
+        });
+        dbg('prototype patch applied');
+      } catch (e) {
+        dbg('prototype patch FAILED: ' + e.message);
+      }
+    } else {
+      dbg('AuthenticatorAttestationResponse not available in initScript');
+    }
   });
 
   context.on('page', async (newPage) => {

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -174,6 +174,21 @@ async function main() {
     }
   );
 
+  // The local NNS II dev build has DISCOVERABLE_PASSKEY_FLOW=true by default, which
+  // routes #authorize to a new /authorize page that calls credentials.get() with empty
+  // allowCredentials on mount for passkey discovery. On headless Linux this throws
+  // NotSupportedError and prevents the passkey UI from rendering.
+  //
+  // Setting this feature flag to false routes II to /legacy/authorize instead, which
+  // does not do discoverable passkey discovery and renders the "Continue with passkey"
+  // button as expected. addInitScript runs on ALL pages (including the II popup) before
+  // any page JavaScript, so localStorage is set before the routing decision is made.
+  await context.addInitScript(() => {
+    try {
+      localStorage.setItem('ii-localstorage-feature-flags__DISCOVERABLE_PASSKEY_FLOW', 'false');
+    } catch (_) {}
+  });
+
   const page = await context.newPage();
 
   // Intercept canister origin — the canister does not need to be running for

--- a/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
+++ b/packages-rs/my-canister-dapp-cli/playwright-js/derive-principal.mjs
@@ -172,6 +172,82 @@ async function main() {
       PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = () =>
         Promise.resolve(true);
     }
+
+    // CDP virtual authenticators on headless Linux return an empty buffer from
+    // AuthenticatorAttestationResponse.getPublicKey(), which causes II's DER parser
+    // (DataView.getUint16) to throw "Offset is outside the bounds of the DataView".
+    // Fix: wrap credentials.create() to extract the COSE public key from
+    // getAuthenticatorData() and re-encode it as DER SubjectPublicKeyInfo when
+    // getPublicKey() returns empty.
+    const _origCreate = navigator.credentials.create.bind(navigator.credentials);
+    navigator.credentials.create = async function(options) {
+      const cred = await _origCreate(options);
+      if (!cred || cred.type !== 'public-key' || !cred.response) return cred;
+
+      // Check if getPublicKey already works
+      let pk = null;
+      try { pk = cred.response.getPublicKey(); } catch (e) { /* ignore */ }
+      if (pk && pk.byteLength > 0) return cred;
+
+      // Extract public key from authenticatorData COSE key and re-encode as DER SPKI
+      try {
+        const authData = new Uint8Array(cred.response.getAuthenticatorData());
+        // authenticatorData layout:
+        //   rpIdHash(32) + flags(1) + signCount(4) + AAGUID(16) = 53 bytes
+        //   + credIdLen(2) + credId(N) + coseKey(...)
+        let offset = 53;
+        const credIdLen = (authData[offset] << 8) | authData[offset + 1];
+        offset += 2 + credIdLen;
+        const cose = authData.subarray(offset);
+
+        // Locate x(-2) and y(-3) in COSE map.
+        // Canonical P-256 COSE key has the pattern:
+        //   0x21 0x58 0x20 <32-byte x>  0x22 0x58 0x20 <32-byte y>
+        let xi = -1, yi = -1;
+        for (let i = 0; i < cose.length - 67; i++) {
+          if (cose[i]    === 0x21 && cose[i+1]  === 0x58 && cose[i+2]  === 0x20 &&
+              cose[i+35] === 0x22 && cose[i+36] === 0x58 && cose[i+37] === 0x20) {
+            xi = i + 3;
+            yi = i + 38;
+            break;
+          }
+        }
+        if (xi < 0) return cred; // pattern not found — return unpatched
+
+        // Build DER SubjectPublicKeyInfo for EC P-256 (91 bytes total)
+        const der = new Uint8Array(91);
+        const prefix = [
+          0x30, 0x59,                                           // SEQUENCE (89)
+          0x30, 0x13,                                           //   SEQUENCE (19)
+          0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, //     OID ecPublicKey
+          0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, // OID P-256
+          0x03, 0x42, 0x00, 0x04,                               //   BIT STRING, uncompressed
+        ];
+        prefix.forEach((b, i) => { der[i] = b; });
+        der.set(cose.subarray(xi, xi + 32), prefix.length);
+        der.set(cose.subarray(yi, yi + 32), prefix.length + 32);
+        const derBuf = der.buffer;
+
+        // Wrap the credential in a Proxy so response.getPublicKey() returns the DER key
+        const origResponse = cred.response;
+        const patchedResponse = new Proxy(origResponse, {
+          get(target, prop) {
+            if (prop === 'getPublicKey') return () => derBuf;
+            const val = target[prop];
+            return typeof val === 'function' ? val.bind(target) : val;
+          },
+        });
+        return new Proxy(cred, {
+          get(target, prop) {
+            if (prop === 'response') return patchedResponse;
+            const val = target[prop];
+            return typeof val === 'function' ? val.bind(target) : val;
+          },
+        });
+      } catch (e) {
+        return cred; // Return unpatched on any error
+      }
+    };
   });
 
   context.on('page', async (newPage) => {

--- a/packages-rs/my-canister-dapp-test/src/lib.rs
+++ b/packages-rs/my-canister-dapp-test/src/lib.rs
@@ -433,16 +433,13 @@ pub fn run_acceptance_suite(wasm_bytes: &[u8], wasm_label: &str) {
     assert_header_contains(&fallback_resp, "content-type", "text/html");
 
     // ─── Security/privacy headers on frontend responses ─────────────────
-    // The frontend crate adds 8 security headers to every asset response.
+    // The frontend crate adds 6 security headers to every asset response.
+    // (X-XSS-Protection and Strict-Transport-Security are intentionally omitted:
+    //  X-XSS-Protection is a legacy IE/old-Chrome header ignored by modern browsers;
+    //  HSTS is redundant on ICP since the gateway enforces HTTPS.)
     assert_header_contains(&fallback_resp, "x-content-type-options", "nosniff");
     assert_header_contains(&fallback_resp, "x-frame-options", "deny");
     assert_header_contains(&fallback_resp, "referrer-policy", "no-referrer");
-    assert_header_contains(&fallback_resp, "x-xss-protection", "0");
-    assert_header_contains(
-        &fallback_resp,
-        "strict-transport-security",
-        "max-age=31536000",
-    );
     assert_header_contains(&fallback_resp, "permissions-policy", "accelerometer=()");
     assert_header_contains(
         &fallback_resp,
@@ -454,7 +451,7 @@ pub fn run_acceptance_suite(wasm_bytes: &[u8], wasm_label: &str) {
         "cross-origin-resource-policy",
         "same-origin",
     );
-    println!("Frontend security headers OK (8/8 verified on fallback response)");
+    println!("Frontend security headers OK (6/6 verified on fallback response)");
 
     // ─── Gzip compression ───────────────────────────────────────────────
     // Request with Accept-Encoding: gzip should return compressed content.

--- a/packages-rs/my-canister-frontend/CHANGELOG.md
+++ b/packages-rs/my-canister-frontend/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- `StandardHeader` enum for typed exclusion of default security headers
+- `FrontendConfig::excluded_headers: Vec<StandardHeader>` — omit specific default headers from every response
+- `FrontendConfig::extra_headers: Vec<(String, String)>` — add headers to every response; a name matching a default (case-insensitive) replaces that default rather than duplicating it
+
 ### Fixed
 
 - Removed unused foo file from package
@@ -10,8 +16,11 @@
 ### Changed
 
 - Updated terminology: "Canister Dapp" → "User-owned dapp" in package description and documentation
+- **Breaking**: `FrontendConfig` gains two new fields (`excluded_headers`, `extra_headers`); struct literals must add `..Default::default()` to remain valid
 - **Breaking**: `FrontendConfig` no longer has a `max_file_size` field; the size limit is fixed and non-configurable. Remove any `max_file_size` assignments from `FrontendConfig` struct literals.
 - **Breaking**: `DEFAULT_MAX_FILE_SIZE` constant removed from the public API.
+- `X-XSS-Protection: 0` removed from default headers (legacy IE/old-Chrome header; add via `extra_headers` if still needed)
+- `Strict-Transport-Security` removed from default headers (ICP gateway enforces HTTPS; redundant on `.icp0.io`/`.ic0.app` domains; add via `extra_headers` for custom domains)
 
 ## [0.3.0] - 2026-02-27
 

--- a/packages-rs/my-canister-frontend/CHANGELOG.md
+++ b/packages-rs/my-canister-frontend/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `StandardHeader` enum for typed exclusion of default security headers
 - `FrontendConfig::excluded_headers: Vec<StandardHeader>` — omit specific default headers from every response
 - `FrontendConfig::extra_headers: Vec<(String, String)>` — add headers to every response; a name matching a default (case-insensitive) replaces that default rather than duplicating it
+- `MAX_FILE_SIZE: usize` public constant (2,080,768 bytes) — replaces the removed `DEFAULT_MAX_FILE_SIZE`; reference it when you need to check the limit at compile time
 
 ### Fixed
 
@@ -18,9 +19,14 @@
 - Updated terminology: "Canister Dapp" → "User-owned dapp" in package description and documentation
 - **Breaking**: `FrontendConfig` gains two new fields (`excluded_headers`, `extra_headers`); struct literals must add `..Default::default()` to remain valid
 - **Breaking**: `FrontendConfig` no longer has a `max_file_size` field; the size limit is fixed and non-configurable. Remove any `max_file_size` assignments from `FrontendConfig` struct literals.
-- **Breaking**: `DEFAULT_MAX_FILE_SIZE` constant removed from the public API.
+- **Breaking**: `DEFAULT_MAX_FILE_SIZE` constant removed from the public API; use `MAX_FILE_SIZE` instead.
 - `X-XSS-Protection: 0` removed from default headers (legacy IE/old-Chrome header; add via `extra_headers` if still needed)
 - `Strict-Transport-Security` removed from default headers (ICP gateway enforces HTTPS; redundant on `.icp0.io`/`.ic0.app` domains; add via `extra_headers` for custom domains)
+- README tagline extended to mention static serving
+
+### Tests
+
+- Added test asserting that `.gz` files are rejected at validation with a clear "not in the allowed list" error, preventing a confusing duplicate-path error that would otherwise surface if a user manually includes a pre-compressed file alongside its source
 
 ## [0.3.0] - 2026-02-27
 

--- a/packages-rs/my-canister-frontend/CHANGELOG.md
+++ b/packages-rs/my-canister-frontend/CHANGELOG.md
@@ -5,10 +5,13 @@
 ### Fixed
 
 - Removed unused foo file from package
+- Max file size reduced from 2 MiB to 2 MiB − 16 KiB (2,080,768 bytes) so that total HTTP responses (body + `IC-Certificate` header + security headers) always fit within ICP's 2 MiB query response limit
 
 ### Changed
 
 - Updated terminology: "Canister Dapp" → "User-owned dapp" in package description and documentation
+- **Breaking**: `FrontendConfig` no longer has a `max_file_size` field; the size limit is fixed and non-configurable. Remove any `max_file_size` assignments from `FrontendConfig` struct literals.
+- **Breaking**: `DEFAULT_MAX_FILE_SIZE` constant removed from the public API.
 
 ## [0.3.0] - 2026-02-27
 

--- a/packages-rs/my-canister-frontend/Cargo.toml
+++ b/packages-rs/my-canister-frontend/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/Web3NL/my-canister-dapp/tree/main/packages-rs/m
 crate-type = ["rlib"]
 
 [dependencies]
+candid.workspace = true
 ic-asset-certification.workspace = true
 ic-http-certification.workspace = true
 ic-cdk.workspace = true

--- a/packages-rs/my-canister-frontend/Cargo.toml
+++ b/packages-rs/my-canister-frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "my-canister-frontend"
 version = "0.3.0"
-description = "Frontend asset utilities for user-owned dapps on the Internet Computer"
+description = "Frontend asset processing library for canisters on the Internet Computer"
 documentation = "https://docs.rs/my-canister-frontend"
 readme = "README.md"
 keywords = ["internet-computer", "canister", "frontend", "assets", "dapp"]
@@ -15,7 +15,6 @@ repository = "https://github.com/Web3NL/my-canister-dapp/tree/main/packages-rs/m
 crate-type = ["rlib"]
 
 [dependencies]
-candid.workspace = true
 ic-asset-certification.workspace = true
 ic-http-certification.workspace = true
 ic-cdk.workspace = true

--- a/packages-rs/my-canister-frontend/Cargo.toml
+++ b/packages-rs/my-canister-frontend/Cargo.toml
@@ -16,12 +16,12 @@ crate-type = ["rlib"]
 
 [dependencies]
 candid.workspace = true
+flate2.workspace = true
 ic-asset-certification.workspace = true
-ic-http-certification.workspace = true
 ic-cdk.workspace = true
+ic-http-certification.workspace = true
 include_dir.workspace = true
 mime_guess.workspace = true
-flate2.workspace = true
 
 [package.metadata.release]
 pre-release-replacements = [

--- a/packages-rs/my-canister-frontend/README.md
+++ b/packages-rs/my-canister-frontend/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://github.com/Web3NL/my-canister-dapp/workflows/Release/badge.svg)](https://github.com/Web3NL/my-canister-dapp/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-Frontend asset processing library for canisters on the Internet Computer.
+Frontend asset processing and static serving library for canisters on the Internet Computer.
 
 ## Usage
 

--- a/packages-rs/my-canister-frontend/README.md
+++ b/packages-rs/my-canister-frontend/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://github.com/Web3NL/my-canister-dapp/workflows/Release/badge.svg)](https://github.com/Web3NL/my-canister-dapp/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-Frontend asset processing library for user-owned dapps on the Internet Computer.
+Frontend asset processing library for canisters on the Internet Computer.
 
 ## Usage
 
@@ -21,7 +21,7 @@ static ASSETS: Dir = include_dir!("$CARGO_MANIFEST_DIR/../dapp-frontend/dist");
 
 #[init]
 fn init() {
-	setup_frontend(&ASSETS);
+	setup_frontend(&ASSETS).expect("Failed to setup frontend");
 }
 
 #[query]
@@ -37,16 +37,18 @@ fn http_request(req: HttpRequest) -> HttpResponse {
 - Automatic MIME type detection using `mime_guess`
 - `index.html` auto-configured as fallback for `/`
 - Certification using [`ic-asset-certification`](https://docs.rs/ic-asset-certification)
-- **Security headers**: 8 default security/privacy headers on all responses (HSTS, X-Frame-Options, Referrer-Policy, etc.)
-- **Asset validation**: File type allowlist, 2 MB size limit, path traversal protection, duplicate detection
+- **Security headers**: 6 default security/privacy headers on all responses (X-Frame-Options, Referrer-Policy, Permissions-Policy, etc.)
+- **Asset validation**: File type allowlist, 2 MiB − 16 KiB size limit, path traversal protection, duplicate detection
 - **Gzip compression**: Automatic gzip for text-based assets (HTML, JS, CSS, JSON, SVG)
-- **Configurable**: Use `FrontendConfig` to allow additional file types or adjust size limits
+- **Configurable**: Use `FrontendConfig` to allow additional file types, suppress default headers, or add custom headers
 - Exposes `with_asset_router` and `with_asset_router_mut` for access to the asset router, see example below.
 - Exposes `asset_router_configs` if you want to implement your own asset router, see [this example](https://github.com/Web3NL/my-canister-dapp/blob/e8fdc0ac81f7bdc702418c05130ace3f9f5399fb/examples/my-hello-world/src/backend/src/lib.rs).
 
 ## Configuration
 
-To allow additional file types or customize settings:
+`FrontendConfig` controls which file types are accepted and what HTTP headers are sent with every response. All fields have sensible defaults — only set what you need, and use `..Default::default()` to fill in the rest.
+
+### Allow additional file types
 
 ```rust,ignore
 use ic_cdk::init;
@@ -65,37 +67,61 @@ fn init() {
 }
 ```
 
-## Usage with [`my_canister_dashboard`](https://crates.io/crates/my-canister-dashboard)
+### Default security headers
+
+Every response includes these headers out of the box:
+
+| Header | Value |
+|---|---|
+| `X-Content-Type-Options` | `nosniff` |
+| `X-Frame-Options` | `DENY` |
+| `Referrer-Policy` | `no-referrer` |
+| `Permissions-Policy` | `accelerometer=(), camera=(), geolocation=(), microphone=(), payment=(), usb=()` |
+| `Cross-Origin-Opener-Policy` | `same-origin-allow-popups` |
+| `Cross-Origin-Resource-Policy` | `same-origin` |
+
+`Strict-Transport-Security` is intentionally omitted — ICP gateways enforce HTTPS at the infrastructure level, making it redundant on `.icp0.io`/`.ic0.app` domains. `X-XSS-Protection` is also omitted as it is a legacy header for old IE/Chrome versions. Both can be added via `extra_headers` if needed.
+
+### Suppress a default header
+
+Use `excluded_headers` with a `StandardHeader` variant to remove a specific default:
 
 ```rust,ignore
-use ic_cdk::{init, query};
-use ic_http_certification::{HttpRequest, HttpResponse};
-use include_dir::{include_dir, Dir};
-use my_canister_dashboard::setup_dashboard_assets;
-use my_canister_frontend::setup_frontend;
-use my_canister_frontend::asset_router::with_asset_router_mut;
+use my_canister_frontend::{setup_frontend_with_config, FrontendConfig, StandardHeader};
 
-static ASSETS: Dir = include_dir!("$CARGO_MANIFEST_DIR/../dapp-frontend/dist");
+let config = FrontendConfig {
+    excluded_headers: vec![StandardHeader::XFrameOptions],
+    ..Default::default()
+};
+```
 
-#[init]
-fn init() {
-	setup_frontend(&ASSETS);
+### Add or override headers
 
-    // Setup dashboard in internal asset router
-    with_asset_router_mut(|router| {
-        setup_dashboard_assets(
-            router,
-            Some(vec![
-                "https://mycanister.app".to_string(),
-            ]),
-        );
-    });
-}
+Use `extra_headers` to append headers to every response. If the name matches a default header (case-insensitive), the default is replaced rather than duplicated:
 
-#[query]
-fn http_request(req: HttpRequest) -> HttpResponse {
-	my_canister_frontend::http_request(req)
-}
+```rust,ignore
+use my_canister_frontend::{setup_frontend_with_config, FrontendConfig};
+
+let config = FrontendConfig {
+    // Replaces the default X-Frame-Options: DENY
+    extra_headers: vec![
+        ("X-Frame-Options".to_string(), "SAMEORIGIN".to_string()),
+        ("Content-Security-Policy".to_string(), "default-src 'self'".to_string()),
+    ],
+    ..Default::default()
+};
+```
+
+To add HSTS on a custom domain:
+
+```rust,ignore
+let config = FrontendConfig {
+    extra_headers: vec![(
+        "Strict-Transport-Security".to_string(),
+        "max-age=31536000; includeSubDomains".to_string(),
+    )],
+    ..Default::default()
+};
 ```
 
 ## License

--- a/packages-rs/my-canister-frontend/README.md
+++ b/packages-rs/my-canister-frontend/README.md
@@ -41,8 +41,8 @@ fn http_request(req: HttpRequest) -> HttpResponse {
 - **Asset validation**: File type allowlist, 2 MiB − 16 KiB size limit, path traversal protection, duplicate detection
 - **Gzip compression**: Automatic gzip for text-based assets (HTML, JS, CSS, JSON, SVG)
 - **Configurable**: Use `FrontendConfig` to allow additional file types, suppress default headers, or add custom headers
-- Exposes `with_asset_router` and `with_asset_router_mut` for access to the asset router, see example below.
-- Exposes `asset_router_configs` if you want to implement your own asset router, see [this example](https://github.com/Web3NL/my-canister-dapp/blob/e8fdc0ac81f7bdc702418c05130ace3f9f5399fb/examples/my-hello-world/src/backend/src/lib.rs).
+- Exposes `with_asset_router` and `with_asset_router_mut` for direct access to the internal asset router
+- Exposes `asset_router_configs` and `asset_router_configs_with_config` for building your own asset router pipeline
 
 ## Configuration
 
@@ -79,8 +79,6 @@ Every response includes these headers out of the box:
 | `Permissions-Policy` | `accelerometer=(), camera=(), geolocation=(), microphone=(), payment=(), usb=()` |
 | `Cross-Origin-Opener-Policy` | `same-origin-allow-popups` |
 | `Cross-Origin-Resource-Policy` | `same-origin` |
-
-`Strict-Transport-Security` is intentionally omitted — ICP gateways enforce HTTPS at the infrastructure level, making it redundant on `.icp0.io`/`.ic0.app` domains. `X-XSS-Protection` is also omitted as it is a legacy header for old IE/Chrome versions. Both can be added via `extra_headers` if needed.
 
 ### Suppress a default header
 

--- a/packages-rs/my-canister-frontend/src/asset_router.rs
+++ b/packages-rs/my-canister-frontend/src/asset_router.rs
@@ -292,7 +292,7 @@ mod tests {
 
         #[test]
         fn max_file_size_is_below_2mib() {
-            assert!(MAX_FILE_SIZE < 2 * 1024 * 1024);
+            const { assert!(MAX_FILE_SIZE < 2 * 1024 * 1024) };
             assert_eq!(MAX_FILE_SIZE, 2 * 1024 * 1024 - 16 * 1024);
         }
 
@@ -651,7 +651,6 @@ mod tests {
         fn allows_extra_extension() {
             let config = FrontendConfig {
                 extra_allowed_extensions: vec!["webmanifest".to_string()],
-                ..Default::default()
             };
             assert!(validate_asset("/manifest.webmanifest", 100, &config).is_ok());
         }
@@ -660,7 +659,6 @@ mod tests {
         fn extra_extension_case_insensitive() {
             let config = FrontendConfig {
                 extra_allowed_extensions: vec!["WebManifest".to_string()],
-                ..Default::default()
             };
             assert!(validate_asset("/manifest.webmanifest", 100, &config).is_ok());
         }

--- a/packages-rs/my-canister-frontend/src/asset_router.rs
+++ b/packages-rs/my-canister-frontend/src/asset_router.rs
@@ -224,7 +224,7 @@ fn gzip_compress(data: &[u8]) -> Result<Vec<u8>, String> {
 
 fn create_asset_config(path: &str, include_gzip: bool) -> AssetConfig {
     let content_type = infer_content_type(path);
-    let headers = create_default_headers(&content_type);
+    let headers = create_default_headers();
     let (fallback_for, aliased_by) = if path == "/index.html" {
         (
             vec![AssetFallbackConfig {
@@ -261,7 +261,7 @@ fn infer_content_type(path: &str) -> String {
         .unwrap_or_else(|| "application/octet-stream".to_string())
 }
 
-fn create_default_headers(_content_type: &str) -> Vec<(String, String)> {
+fn create_default_headers() -> Vec<(String, String)> {
     vec![
         ("X-Content-Type-Options".into(), "nosniff".into()),
         ("X-Frame-Options".into(), "DENY".into()),
@@ -548,37 +548,37 @@ mod tests {
 
         #[test]
         fn returns_eight_headers() {
-            let headers = create_default_headers("text/html");
+            let headers = create_default_headers();
             assert_eq!(headers.len(), 8);
         }
 
         #[test]
         fn includes_x_content_type_options() {
-            let headers = create_default_headers("text/html");
+            let headers = create_default_headers();
             assert!(headers.contains(&("X-Content-Type-Options".into(), "nosniff".into())));
         }
 
         #[test]
         fn includes_x_frame_options() {
-            let headers = create_default_headers("text/html");
+            let headers = create_default_headers();
             assert!(headers.contains(&("X-Frame-Options".into(), "DENY".into())));
         }
 
         #[test]
         fn includes_referrer_policy() {
-            let headers = create_default_headers("text/html");
+            let headers = create_default_headers();
             assert!(headers.contains(&("Referrer-Policy".into(), "no-referrer".into())));
         }
 
         #[test]
         fn includes_xss_protection_disabled() {
-            let headers = create_default_headers("text/html");
+            let headers = create_default_headers();
             assert!(headers.contains(&("X-XSS-Protection".into(), "0".into())));
         }
 
         #[test]
         fn includes_hsts() {
-            let headers = create_default_headers("text/html");
+            let headers = create_default_headers();
             assert!(headers.contains(&(
                 "Strict-Transport-Security".into(),
                 "max-age=31536000; includeSubDomains".into()
@@ -587,7 +587,7 @@ mod tests {
 
         #[test]
         fn includes_permissions_policy() {
-            let headers = create_default_headers("text/html");
+            let headers = create_default_headers();
             assert!(headers.contains(&(
                 "Permissions-Policy".into(),
                 "accelerometer=(), camera=(), geolocation=(), microphone=(), payment=(), usb=()"
@@ -597,7 +597,7 @@ mod tests {
 
         #[test]
         fn includes_cross_origin_opener_policy() {
-            let headers = create_default_headers("text/html");
+            let headers = create_default_headers();
             assert!(headers.contains(&(
                 "Cross-Origin-Opener-Policy".into(),
                 "same-origin-allow-popups".into(),
@@ -606,21 +606,12 @@ mod tests {
 
         #[test]
         fn includes_cross_origin_resource_policy() {
-            let headers = create_default_headers("text/html");
+            let headers = create_default_headers();
             assert!(
                 headers.contains(&("Cross-Origin-Resource-Policy".into(), "same-origin".into()))
             );
         }
 
-        #[test]
-        fn same_headers_regardless_of_content_type() {
-            let headers_html = create_default_headers("text/html");
-            let headers_js = create_default_headers("application/javascript");
-            let headers_empty = create_default_headers("");
-
-            assert_eq!(headers_html, headers_js);
-            assert_eq!(headers_js, headers_empty);
-        }
     }
 
     mod validate_asset {

--- a/packages-rs/my-canister-frontend/src/asset_router.rs
+++ b/packages-rs/my-canister-frontend/src/asset_router.rs
@@ -52,11 +52,11 @@ pub enum StandardHeader {
 impl StandardHeader {
     fn header_name(&self) -> &'static str {
         match self {
-            Self::XContentTypeOptions       => "X-Content-Type-Options",
-            Self::XFrameOptions             => "X-Frame-Options",
-            Self::ReferrerPolicy            => "Referrer-Policy",
-            Self::PermissionsPolicy         => "Permissions-Policy",
-            Self::CrossOriginOpenerPolicy   => "Cross-Origin-Opener-Policy",
+            Self::XContentTypeOptions => "X-Content-Type-Options",
+            Self::XFrameOptions => "X-Frame-Options",
+            Self::ReferrerPolicy => "Referrer-Policy",
+            Self::PermissionsPolicy => "Permissions-Policy",
+            Self::CrossOriginOpenerPolicy => "Cross-Origin-Opener-Policy",
             Self::CrossOriginResourcePolicy => "Cross-Origin-Resource-Policy",
         }
     }
@@ -578,7 +578,8 @@ mod tests {
 
         #[test]
         fn nested_path_config() {
-            let config = create_asset_config("/assets/images/logo.png", false, &FrontendConfig::default());
+            let config =
+                create_asset_config("/assets/images/logo.png", false, &FrontendConfig::default());
 
             match config {
                 AssetConfig::File {
@@ -620,8 +621,9 @@ mod tests {
 
         #[test]
         fn includes_x_content_type_options() {
-            assert!(default_headers()
-                .contains(&("X-Content-Type-Options".into(), "nosniff".into())));
+            assert!(
+                default_headers().contains(&("X-Content-Type-Options".into(), "nosniff".into()))
+            );
         }
 
         #[test]
@@ -631,9 +633,7 @@ mod tests {
 
         #[test]
         fn includes_referrer_policy() {
-            assert!(
-                default_headers().contains(&("Referrer-Policy".into(), "no-referrer".into()))
-            );
+            assert!(default_headers().contains(&("Referrer-Policy".into(), "no-referrer".into())));
         }
 
         #[test]
@@ -655,22 +655,28 @@ mod tests {
 
         #[test]
         fn includes_cross_origin_resource_policy() {
-            assert!(default_headers()
-                .contains(&("Cross-Origin-Resource-Policy".into(), "same-origin".into())));
+            assert!(
+                default_headers()
+                    .contains(&("Cross-Origin-Resource-Policy".into(), "same-origin".into()))
+            );
         }
 
         #[test]
         fn does_not_include_xss_protection() {
-            assert!(!default_headers()
-                .iter()
-                .any(|(name, _)| name == "X-XSS-Protection"));
+            assert!(
+                !default_headers()
+                    .iter()
+                    .any(|(name, _)| name == "X-XSS-Protection")
+            );
         }
 
         #[test]
         fn does_not_include_hsts() {
-            assert!(!default_headers()
-                .iter()
-                .any(|(name, _)| name == "Strict-Transport-Security"));
+            assert!(
+                !default_headers()
+                    .iter()
+                    .any(|(name, _)| name == "Strict-Transport-Security")
+            );
         }
 
         #[test]
@@ -694,7 +700,11 @@ mod tests {
                 .iter()
                 .filter(|(name, _)| name == "X-Frame-Options")
                 .collect();
-            assert_eq!(frame_headers.len(), 1, "should have exactly one X-Frame-Options");
+            assert_eq!(
+                frame_headers.len(),
+                1,
+                "should have exactly one X-Frame-Options"
+            );
             assert_eq!(frame_headers[0].1, "SAMEORIGIN");
         }
 
@@ -716,7 +726,10 @@ mod tests {
         #[test]
         fn extra_header_is_appended() {
             let config = FrontendConfig {
-                extra_headers: vec![("Content-Security-Policy".into(), "default-src 'self'".into())],
+                extra_headers: vec![(
+                    "Content-Security-Policy".into(),
+                    "default-src 'self'".into(),
+                )],
                 ..Default::default()
             };
             let headers = build_headers(&config);

--- a/packages-rs/my-canister-frontend/src/asset_router.rs
+++ b/packages-rs/my-canister-frontend/src/asset_router.rs
@@ -16,8 +16,10 @@ pub const DEFAULT_ALLOWED_EXTENSIONS: &[&str] = &[
     "woff2", "ttf", "otf", "eot", "json", "xml", "txt", "wasm", "map",
 ];
 
-/// Maximum file size in bytes (2 MB).
-pub const DEFAULT_MAX_FILE_SIZE: usize = 2 * 1024 * 1024;
+// ICP query responses are capped at 2 MiB. Each response includes ~3.5 KB of
+// HTTP headers (IC-Certificate, security headers, Content-Type, etc.) on top of
+// the body. Reserve 16 KiB to ensure the total response always fits.
+const MAX_FILE_SIZE: usize = 2 * 1024 * 1024 - 16 * 1024;
 
 /// File extensions that benefit from gzip compression.
 /// Binary formats (images, fonts, wasm) are already compressed.
@@ -30,22 +32,11 @@ const COMPRESSIBLE_EXTENSIONS: &[&str] = &[
 /// Use with [`asset_router_configs_with_config`] or
 /// [`setup_frontend_with_config`](crate::setup_frontend_with_config) to
 /// customise validation beyond the defaults.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct FrontendConfig {
     /// Additional file extensions to allow beyond [`DEFAULT_ALLOWED_EXTENSIONS`].
     /// Extensions should be specified without the leading dot (e.g. `"webmanifest"`).
     pub extra_allowed_extensions: Vec<String>,
-    /// Maximum file size in bytes. Defaults to [`DEFAULT_MAX_FILE_SIZE`] (2 MB).
-    pub max_file_size: usize,
-}
-
-impl Default for FrontendConfig {
-    fn default() -> Self {
-        Self {
-            extra_allowed_extensions: Vec::new(),
-            max_file_size: DEFAULT_MAX_FILE_SIZE,
-        }
-    }
 }
 
 thread_local! {
@@ -88,7 +79,7 @@ pub fn asset_router_configs(
 ///
 /// All assets are validated against the [`FrontendConfig`] rules:
 /// - File extension must be in [`DEFAULT_ALLOWED_EXTENSIONS`] or `config.extra_allowed_extensions`
-/// - File size must not exceed `config.max_file_size`
+/// - File size must not exceed the internal limit (2 MiB − 16 KiB)
 /// - Paths must not contain `..`, `//`, or invalid URL characters
 /// - Duplicate paths are rejected
 ///
@@ -206,10 +197,9 @@ fn validate_asset(path: &str, size: usize, config: &FrontendConfig) -> Result<()
         }
     }
     // File size
-    if size > config.max_file_size {
+    if size > MAX_FILE_SIZE {
         return Err(format!(
-            "File size ({size} bytes) exceeds maximum ({} bytes): {path}",
-            config.max_file_size
+            "File size ({size} bytes) exceeds maximum ({MAX_FILE_SIZE} bytes): {path}"
         ));
     }
     Ok(())
@@ -301,9 +291,9 @@ mod tests {
         use super::*;
 
         #[test]
-        fn default_max_file_size_is_2mb() {
-            let config = FrontendConfig::default();
-            assert_eq!(config.max_file_size, 2 * 1024 * 1024);
+        fn max_file_size_is_below_2mib() {
+            assert!(MAX_FILE_SIZE < 2 * 1024 * 1024);
+            assert_eq!(MAX_FILE_SIZE, 2 * 1024 * 1024 - 16 * 1024);
         }
 
         #[test]
@@ -695,24 +685,14 @@ mod tests {
         #[test]
         fn allows_file_at_size_limit() {
             let config = FrontendConfig::default();
-            assert!(validate_asset("/exact.html", DEFAULT_MAX_FILE_SIZE, &config).is_ok());
+            assert!(validate_asset("/exact.html", MAX_FILE_SIZE, &config).is_ok());
         }
 
         #[test]
         fn rejects_file_one_byte_over_limit() {
             let config = FrontendConfig::default();
-            let result = validate_asset("/over.html", DEFAULT_MAX_FILE_SIZE + 1, &config);
+            let result = validate_asset("/over.html", MAX_FILE_SIZE + 1, &config);
             assert!(result.is_err());
-        }
-
-        #[test]
-        fn custom_max_file_size() {
-            let config = FrontendConfig {
-                max_file_size: 500,
-                ..Default::default()
-            };
-            assert!(validate_asset("/small.html", 500, &config).is_ok());
-            assert!(validate_asset("/big.html", 501, &config).is_err());
         }
 
         #[test]

--- a/packages-rs/my-canister-frontend/src/asset_router.rs
+++ b/packages-rs/my-canister-frontend/src/asset_router.rs
@@ -27,16 +27,61 @@ const COMPRESSIBLE_EXTENSIONS: &[&str] = &[
     "html", "js", "mjs", "css", "json", "svg", "xml", "txt", "map",
 ];
 
+/// A default security header that can be excluded from responses via [`FrontendConfig::excluded_headers`].
+///
+/// Each variant corresponds to one of the headers set by default on every response.
+/// Use this with [`FrontendConfig::excluded_headers`] to suppress specific defaults,
+/// and [`FrontendConfig::extra_headers`] to replace them with custom values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StandardHeader {
+    /// `X-Content-Type-Options: nosniff` — prevents MIME-sniffing attacks.
+    XContentTypeOptions,
+    /// `X-Frame-Options: DENY` — prevents clickjacking via iframe embedding.
+    XFrameOptions,
+    /// `Referrer-Policy: no-referrer` — prevents the URL from leaking via the Referer header.
+    ReferrerPolicy,
+    /// `Permissions-Policy: accelerometer=(), camera=(), ...` — restricts hardware API access.
+    PermissionsPolicy,
+    /// `Cross-Origin-Opener-Policy: same-origin-allow-popups` — isolates the browsing context
+    /// while still allowing Internet Identity popup authentication flows.
+    CrossOriginOpenerPolicy,
+    /// `Cross-Origin-Resource-Policy: same-origin` — prevents other origins from loading your assets.
+    CrossOriginResourcePolicy,
+}
+
+impl StandardHeader {
+    fn header_name(&self) -> &'static str {
+        match self {
+            Self::XContentTypeOptions       => "X-Content-Type-Options",
+            Self::XFrameOptions             => "X-Frame-Options",
+            Self::ReferrerPolicy            => "Referrer-Policy",
+            Self::PermissionsPolicy         => "Permissions-Policy",
+            Self::CrossOriginOpenerPolicy   => "Cross-Origin-Opener-Policy",
+            Self::CrossOriginResourcePolicy => "Cross-Origin-Resource-Policy",
+        }
+    }
+}
+
 /// Configuration for frontend asset processing.
 ///
 /// Use with [`asset_router_configs_with_config`] or
 /// [`setup_frontend_with_config`](crate::setup_frontend_with_config) to
-/// customise validation beyond the defaults.
+/// customise validation and HTTP headers beyond the defaults.
 #[derive(Debug, Clone, Default)]
 pub struct FrontendConfig {
     /// Additional file extensions to allow beyond [`DEFAULT_ALLOWED_EXTENSIONS`].
     /// Extensions should be specified without the leading dot (e.g. `"webmanifest"`).
     pub extra_allowed_extensions: Vec<String>,
+    /// Default security headers to omit from responses.
+    ///
+    /// Each [`StandardHeader`] variant named here is removed from the default set.
+    /// Use [`FrontendConfig::extra_headers`] to supply a replacement value.
+    pub excluded_headers: Vec<StandardHeader>,
+    /// Additional headers included on every asset response.
+    ///
+    /// If any entry's name matches a default header (case-insensitive), the default
+    /// is replaced by this value rather than both appearing in the response.
+    pub extra_headers: Vec<(String, String)>,
 }
 
 thread_local! {
@@ -136,7 +181,7 @@ fn process_dir_recursive(
             let gzipped = gzip_compress(contents)?;
             assets.push(Asset::new(format!("{full_path}.gz"), gzipped));
         }
-        let cfg = create_asset_config(&full_path, compressible);
+        let cfg = create_asset_config(&full_path, compressible, config);
         asset_configs.push(cfg);
     }
     for subdir in dir.dirs() {
@@ -222,9 +267,9 @@ fn gzip_compress(data: &[u8]) -> Result<Vec<u8>, String> {
         .map_err(|e| format!("Gzip finalization failed: {e}"))
 }
 
-fn create_asset_config(path: &str, include_gzip: bool) -> AssetConfig {
+fn create_asset_config(path: &str, include_gzip: bool, config: &FrontendConfig) -> AssetConfig {
     let content_type = infer_content_type(path);
-    let headers = create_default_headers();
+    let headers = build_headers(config);
     let (fallback_for, aliased_by) = if path == "/index.html" {
         (
             vec![AssetFallbackConfig {
@@ -261,16 +306,23 @@ fn infer_content_type(path: &str) -> String {
         .unwrap_or_else(|| "application/octet-stream".to_string())
 }
 
-fn create_default_headers() -> Vec<(String, String)> {
-    vec![
+fn build_headers(config: &FrontendConfig) -> Vec<(String, String)> {
+    let excluded_names: Vec<&str> = config
+        .excluded_headers
+        .iter()
+        .map(|h| h.header_name())
+        .collect();
+
+    let extra_names: Vec<&str> = config
+        .extra_headers
+        .iter()
+        .map(|(name, _)| name.as_str())
+        .collect();
+
+    let mut headers: Vec<(String, String)> = vec![
         ("X-Content-Type-Options".into(), "nosniff".into()),
         ("X-Frame-Options".into(), "DENY".into()),
         ("Referrer-Policy".into(), "no-referrer".into()),
-        ("X-XSS-Protection".into(), "0".into()),
-        (
-            "Strict-Transport-Security".into(),
-            "max-age=31536000; includeSubDomains".into(),
-        ),
         (
             "Permissions-Policy".into(),
             "accelerometer=(), camera=(), geolocation=(), microphone=(), payment=(), usb=()".into(),
@@ -281,6 +333,17 @@ fn create_default_headers() -> Vec<(String, String)> {
         ),
         ("Cross-Origin-Resource-Policy".into(), "same-origin".into()),
     ]
+    .into_iter()
+    .filter(|(name, _): &(String, String)| {
+        !excluded_names.contains(&name.as_str())
+            && !extra_names
+                .iter()
+                .any(|e| e.eq_ignore_ascii_case(name.as_str()))
+    })
+    .collect();
+
+    headers.extend(config.extra_headers.iter().cloned());
+    headers
 }
 
 #[cfg(test)]
@@ -442,7 +505,7 @@ mod tests {
 
         #[test]
         fn index_html_has_fallback_and_alias() {
-            let config = create_asset_config("/index.html", false);
+            let config = create_asset_config("/index.html", false, &FrontendConfig::default());
 
             match config {
                 AssetConfig::File {
@@ -465,7 +528,7 @@ mod tests {
 
         #[test]
         fn non_index_html_has_no_fallback() {
-            let config = create_asset_config("/other.html", false);
+            let config = create_asset_config("/other.html", false, &FrontendConfig::default());
 
             match config {
                 AssetConfig::File {
@@ -486,7 +549,7 @@ mod tests {
 
         #[test]
         fn js_file_config() {
-            let config = create_asset_config("/app.js", false);
+            let config = create_asset_config("/app.js", false, &FrontendConfig::default());
 
             match config {
                 AssetConfig::File {
@@ -515,7 +578,7 @@ mod tests {
 
         #[test]
         fn nested_path_config() {
-            let config = create_asset_config("/assets/images/logo.png", false);
+            let config = create_asset_config("/assets/images/logo.png", false, &FrontendConfig::default());
 
             match config {
                 AssetConfig::File {
@@ -530,7 +593,7 @@ mod tests {
 
         #[test]
         fn config_uses_identity_encoding() {
-            let config = create_asset_config("/style.css", false);
+            let config = create_asset_config("/style.css", false, &FrontendConfig::default());
 
             match config {
                 AssetConfig::File { encodings, .. } => {
@@ -543,52 +606,39 @@ mod tests {
         }
     }
 
-    mod create_default_headers {
+    mod build_headers {
         use super::*;
 
+        fn default_headers() -> Vec<(String, String)> {
+            build_headers(&FrontendConfig::default())
+        }
+
         #[test]
-        fn returns_eight_headers() {
-            let headers = create_default_headers();
-            assert_eq!(headers.len(), 8);
+        fn default_config_produces_six_headers() {
+            assert_eq!(default_headers().len(), 6);
         }
 
         #[test]
         fn includes_x_content_type_options() {
-            let headers = create_default_headers();
-            assert!(headers.contains(&("X-Content-Type-Options".into(), "nosniff".into())));
+            assert!(default_headers()
+                .contains(&("X-Content-Type-Options".into(), "nosniff".into())));
         }
 
         #[test]
         fn includes_x_frame_options() {
-            let headers = create_default_headers();
-            assert!(headers.contains(&("X-Frame-Options".into(), "DENY".into())));
+            assert!(default_headers().contains(&("X-Frame-Options".into(), "DENY".into())));
         }
 
         #[test]
         fn includes_referrer_policy() {
-            let headers = create_default_headers();
-            assert!(headers.contains(&("Referrer-Policy".into(), "no-referrer".into())));
-        }
-
-        #[test]
-        fn includes_xss_protection_disabled() {
-            let headers = create_default_headers();
-            assert!(headers.contains(&("X-XSS-Protection".into(), "0".into())));
-        }
-
-        #[test]
-        fn includes_hsts() {
-            let headers = create_default_headers();
-            assert!(headers.contains(&(
-                "Strict-Transport-Security".into(),
-                "max-age=31536000; includeSubDomains".into()
-            )));
+            assert!(
+                default_headers().contains(&("Referrer-Policy".into(), "no-referrer".into()))
+            );
         }
 
         #[test]
         fn includes_permissions_policy() {
-            let headers = create_default_headers();
-            assert!(headers.contains(&(
+            assert!(default_headers().contains(&(
                 "Permissions-Policy".into(),
                 "accelerometer=(), camera=(), geolocation=(), microphone=(), payment=(), usb=()"
                     .into()
@@ -597,8 +647,7 @@ mod tests {
 
         #[test]
         fn includes_cross_origin_opener_policy() {
-            let headers = create_default_headers();
-            assert!(headers.contains(&(
+            assert!(default_headers().contains(&(
                 "Cross-Origin-Opener-Policy".into(),
                 "same-origin-allow-popups".into(),
             )));
@@ -606,10 +655,87 @@ mod tests {
 
         #[test]
         fn includes_cross_origin_resource_policy() {
-            let headers = create_default_headers();
-            assert!(
-                headers.contains(&("Cross-Origin-Resource-Policy".into(), "same-origin".into()))
-            );
+            assert!(default_headers()
+                .contains(&("Cross-Origin-Resource-Policy".into(), "same-origin".into())));
+        }
+
+        #[test]
+        fn does_not_include_xss_protection() {
+            assert!(!default_headers()
+                .iter()
+                .any(|(name, _)| name == "X-XSS-Protection"));
+        }
+
+        #[test]
+        fn does_not_include_hsts() {
+            assert!(!default_headers()
+                .iter()
+                .any(|(name, _)| name == "Strict-Transport-Security"));
+        }
+
+        #[test]
+        fn excluded_header_is_removed() {
+            let config = FrontendConfig {
+                excluded_headers: vec![StandardHeader::XFrameOptions],
+                ..Default::default()
+            };
+            let headers = build_headers(&config);
+            assert!(!headers.iter().any(|(name, _)| name == "X-Frame-Options"));
+        }
+
+        #[test]
+        fn extra_header_replaces_default() {
+            let config = FrontendConfig {
+                extra_headers: vec![("X-Frame-Options".into(), "SAMEORIGIN".into())],
+                ..Default::default()
+            };
+            let headers = build_headers(&config);
+            let frame_headers: Vec<_> = headers
+                .iter()
+                .filter(|(name, _)| name == "X-Frame-Options")
+                .collect();
+            assert_eq!(frame_headers.len(), 1, "should have exactly one X-Frame-Options");
+            assert_eq!(frame_headers[0].1, "SAMEORIGIN");
+        }
+
+        #[test]
+        fn extra_header_replace_is_case_insensitive() {
+            let config = FrontendConfig {
+                extra_headers: vec![("x-frame-options".into(), "SAMEORIGIN".into())],
+                ..Default::default()
+            };
+            let headers = build_headers(&config);
+            let frame_headers: Vec<_> = headers
+                .iter()
+                .filter(|(name, _)| name.eq_ignore_ascii_case("x-frame-options"))
+                .collect();
+            assert_eq!(frame_headers.len(), 1);
+            assert_eq!(frame_headers[0].1, "SAMEORIGIN");
+        }
+
+        #[test]
+        fn extra_header_is_appended() {
+            let config = FrontendConfig {
+                extra_headers: vec![("Content-Security-Policy".into(), "default-src 'self'".into())],
+                ..Default::default()
+            };
+            let headers = build_headers(&config);
+            assert!(headers.contains(&(
+                "Content-Security-Policy".into(),
+                "default-src 'self'".into()
+            )));
+        }
+
+        #[test]
+        fn excluded_and_extra_can_combine() {
+            let config = FrontendConfig {
+                excluded_headers: vec![StandardHeader::ReferrerPolicy],
+                extra_headers: vec![("Cache-Control".into(), "no-store".into())],
+                ..Default::default()
+            };
+            let headers = build_headers(&config);
+            assert!(!headers.iter().any(|(name, _)| name == "Referrer-Policy"));
+            assert!(headers.contains(&("Cache-Control".into(), "no-store".into())));
         }
     }
 
@@ -650,6 +776,7 @@ mod tests {
         fn allows_extra_extension() {
             let config = FrontendConfig {
                 extra_allowed_extensions: vec!["webmanifest".to_string()],
+                ..Default::default()
             };
             assert!(validate_asset("/manifest.webmanifest", 100, &config).is_ok());
         }
@@ -658,6 +785,7 @@ mod tests {
         fn extra_extension_case_insensitive() {
             let config = FrontendConfig {
                 extra_allowed_extensions: vec!["WebManifest".to_string()],
+                ..Default::default()
             };
             assert!(validate_asset("/manifest.webmanifest", 100, &config).is_ok());
         }
@@ -805,7 +933,7 @@ mod tests {
 
         #[test]
         fn compressible_config_has_two_encodings() {
-            let config = create_asset_config("/app.js", true);
+            let config = create_asset_config("/app.js", true, &FrontendConfig::default());
             match config {
                 AssetConfig::File { encodings, .. } => {
                     assert_eq!(encodings.len(), 2);
@@ -819,7 +947,7 @@ mod tests {
 
         #[test]
         fn non_compressible_config_has_one_encoding() {
-            let config = create_asset_config("/image.png", false);
+            let config = create_asset_config("/image.png", false, &FrontendConfig::default());
             match config {
                 AssetConfig::File { encodings, .. } => {
                     assert_eq!(encodings.len(), 1);

--- a/packages-rs/my-canister-frontend/src/asset_router.rs
+++ b/packages-rs/my-canister-frontend/src/asset_router.rs
@@ -16,10 +16,12 @@ pub const DEFAULT_ALLOWED_EXTENSIONS: &[&str] = &[
     "woff2", "ttf", "otf", "eot", "json", "xml", "txt", "wasm", "map",
 ];
 
-// ICP query responses are capped at 2 MiB. Each response includes ~3.5 KB of
-// HTTP headers (IC-Certificate, security headers, Content-Type, etc.) on top of
-// the body. Reserve 16 KiB to ensure the total response always fits.
-const MAX_FILE_SIZE: usize = 2 * 1024 * 1024 - 16 * 1024;
+/// Maximum allowed file size in bytes (2 MiB − 16 KiB).
+///
+/// ICP query responses are capped at 2 MiB. Each response includes ~3.5 KB of
+/// HTTP headers (IC-Certificate, security headers, Content-Type, etc.) on top of
+/// the body. 16 KiB is reserved to ensure the total response always fits.
+pub const MAX_FILE_SIZE: usize = 2 * 1024 * 1024 - 16 * 1024;
 
 /// File extensions that benefit from gzip compression.
 /// Binary formats (images, fonts, wasm) are already compressed.
@@ -327,6 +329,8 @@ fn build_headers(config: &FrontendConfig) -> Vec<(String, String)> {
             "Permissions-Policy".into(),
             "accelerometer=(), camera=(), geolocation=(), microphone=(), payment=(), usb=()".into(),
         ),
+        // same-origin-allow-popups is required for Internet Identity authentication,
+        // which opens a popup window to complete the login flow.
         (
             "Cross-Origin-Opener-Policy".into(),
             "same-origin-allow-popups".into(),
@@ -884,6 +888,21 @@ mod tests {
         fn allows_hyphens_and_underscores() {
             let config = FrontendConfig::default();
             assert!(validate_asset("/my-app_v2.js", 100, &config).is_ok());
+        }
+
+        #[test]
+        fn rejects_gz_extension() {
+            // A manually-included .gz file (e.g. app.js.gz) is not in the allowlist.
+            // The crate generates its own .gz variants internally; user-provided ones
+            // would collide with those generated paths and produce a confusing duplicate error.
+            // Rejecting .gz at validation gives a clear, actionable message instead.
+            let config = FrontendConfig::default();
+            let result = validate_asset("/app.js.gz", 100, &config);
+            assert!(result.is_err());
+            assert!(
+                result.unwrap_err().contains("not in the allowed list"),
+                "expected 'not in the allowed list' error for .gz file"
+            );
         }
     }
 

--- a/packages-rs/my-canister-frontend/src/asset_router.rs
+++ b/packages-rs/my-canister-frontend/src/asset_router.rs
@@ -549,7 +549,7 @@ mod tests {
 
         #[test]
         fn js_file_config() {
-            let config = create_asset_config("/app.js", false, &FrontendConfig::default());
+            let config = create_asset_config("/app.js", true, &FrontendConfig::default());
 
             match config {
                 AssetConfig::File {
@@ -569,8 +569,9 @@ mod tests {
                     );
                     assert!(fallback_for.is_empty());
                     assert!(aliased_by.is_empty());
-                    assert_eq!(encodings.len(), 1);
+                    assert_eq!(encodings.len(), 2);
                     assert!(matches!(encodings[0].0, AssetEncoding::Identity));
+                    assert!(matches!(encodings[1].0, AssetEncoding::Gzip));
                 }
                 _ => panic!("Expected AssetConfig::File"),
             }

--- a/packages-rs/my-canister-frontend/src/asset_router.rs
+++ b/packages-rs/my-canister-frontend/src/asset_router.rs
@@ -611,7 +611,6 @@ mod tests {
                 headers.contains(&("Cross-Origin-Resource-Policy".into(), "same-origin".into()))
             );
         }
-
     }
 
     mod validate_asset {

--- a/packages-rs/my-canister-frontend/src/lib.rs
+++ b/packages-rs/my-canister-frontend/src/lib.rs
@@ -9,7 +9,7 @@ use ic_http_certification::{HttpRequest, HttpResponse, StatusCode};
 use include_dir::Dir;
 use std::borrow::Cow;
 
-/// Initialize and certify your user-owned dapp frontend assets.
+/// Initialize and certify frontend assets.
 ///
 /// Embeds files from an [`include_dir`](https://docs.rs/include_dir/latest/include_dir/) `Dir` into the internal
 /// [`AssetRouter`](https://docs.rs/ic-asset-certification/latest/ic_asset_certification/struct.AssetRouter.html)
@@ -38,7 +38,7 @@ pub fn setup_frontend(assets_dir: &Dir<'static>) -> Result<(), String> {
     setup_frontend_with_config(assets_dir, &FrontendConfig::default())
 }
 
-/// Initialize and certify your user-owned dapp frontend assets with custom configuration.
+/// Initialize and certify frontend assets with custom configuration.
 ///
 /// Like [`setup_frontend`], but allows specifying additional allowed file
 /// extensions and other options via [`FrontendConfig`].
@@ -67,9 +67,7 @@ pub fn setup_frontend_with_config(
     })
 }
 
-/// Serve certified frontend assets.
-/// Any other additional assets you may have added to the asset router,
-/// like for example dashboard assets, will also be served.
+/// Serve certified assets from the internal asset router.
 ///
 /// # Example
 /// ```rust,no_run

--- a/packages-rs/my-canister-frontend/src/lib.rs
+++ b/packages-rs/my-canister-frontend/src/lib.rs
@@ -2,7 +2,7 @@
 
 pub mod asset_router;
 
-pub use asset_router::FrontendConfig;
+pub use asset_router::{FrontendConfig, StandardHeader};
 
 use ic_cdk::api::certified_data_set;
 use ic_http_certification::{HttpRequest, HttpResponse, StatusCode};

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
       // subdomains. Explicitly map them to 127.0.0.1 so local PocketIC canisters
       // (e.g. <canister-id>.localhost:8080) and the II canister are reachable.
       // macOS resolves *.localhost natively; this rule is a no-op there.
-      args: ['--host-resolver-rules=MAP *.localhost 127.0.0.1'],
+      args: ['--host-resolver-rules=MAP *.localhost 127.0.0.1,MAP localhost 127.0.0.1'],
     },
   },
   projects: [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,13 @@ export default defineConfig({
   use: {
     ...devices['Desktop Chrome'],
     // headless: false,
+    launchOptions: {
+      // On Ubuntu, Chromium's built-in DNS resolver does not resolve *.localhost
+      // subdomains. Explicitly map them to 127.0.0.1 so local PocketIC canisters
+      // (e.g. <canister-id>.localhost:8080) and the II canister are reachable.
+      // macOS resolves *.localhost natively; this rule is a no-op there.
+      args: ['--host-resolver-rules=MAP *.localhost 127.0.0.1'],
+    },
   },
   projects: [
     {

--- a/tests/canister-dashboard-frontend/alternative-origins.spec.ts
+++ b/tests/canister-dashboard-frontend/alternative-origins.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures.js';
 import { login } from './login';
 import {
   TEST_ORIGINS,

--- a/tests/canister-dashboard-frontend/controllers.spec.ts
+++ b/tests/canister-dashboard-frontend/controllers.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures.js';
 import { login } from './login';
 import {
   TEST_CONTROLLER,

--- a/tests/canister-dashboard-frontend/logs.spec.ts
+++ b/tests/canister-dashboard-frontend/logs.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures.js';
 import { login } from './login';
 import { setupConsoleErrorMonitoring } from './shared';
 

--- a/tests/canister-dashboard-frontend/theme.spec.ts
+++ b/tests/canister-dashboard-frontend/theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures.js';
 import { login } from './login';
 import { setupConsoleErrorMonitoring } from './shared';
 

--- a/tests/canister-dashboard-frontend/topup-rule.spec.ts
+++ b/tests/canister-dashboard-frontend/topup-rule.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures.js';
 import { login } from './login';
 import { setupConsoleErrorMonitoring } from './shared';
 

--- a/tests/canister-dashboard-frontend/topup.spec.ts
+++ b/tests/canister-dashboard-frontend/topup.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures.js';
 import { login, checkPrincipal } from './login';
 import { formatIcpBalance } from '../../packages-rs/my-canister-dashboard/frontend/src/helpers';
 import {

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -4,7 +4,7 @@
  * Applies the same fixes as derive-principal.mjs to every test context:
  *   1. addInitScript: isUserVerifyingPlatformAuthenticatorAvailable → true
  *   2. addInitScript: credentials.get → NotAllowedError (stops UI from blocking)
- *   3. context.route: Node.js HTTP proxy for *.localhost (DNS + gzip + bundle patch)
+ *   3. context.route: Node.js HTTP proxy for *.localhost and localhost (DNS + CORS bypass + gzip + bundle patch)
  *   4. II bundle patch: force DUMMY_AUTH path (Vr.dummy_auth check → true)
  *   5. II bundle patch: unique seed per context (avoids credential conflicts between tests)
  */
@@ -36,7 +36,7 @@ async function applyIIPatches(context: BrowserContext, seed: number): Promise<vo
   });
 
   await context.route(
-    (url) => url.hostname !== 'localhost' && url.hostname.endsWith('.localhost'),
+    (url) => url.hostname === 'localhost' || url.hostname.endsWith('.localhost'),
     (route) => {
       const url = new URL(route.request().url());
       const req = http.request(

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,0 +1,104 @@
+/**
+ * Playwright test fixtures with II headless Linux CI patches.
+ *
+ * Applies the same fixes as derive-principal.mjs to every test context:
+ *   1. addInitScript: isUserVerifyingPlatformAuthenticatorAvailable → true
+ *   2. addInitScript: credentials.get → NotAllowedError (stops UI from blocking)
+ *   3. context.route: Node.js HTTP proxy for *.localhost (DNS + gzip + bundle patch)
+ *   4. II bundle patch: force DUMMY_AUTH path (Vr.dummy_auth check → true)
+ *   5. II bundle patch: unique seed per context (avoids credential conflicts between tests)
+ */
+import { test as base } from '@playwright/test';
+import type { BrowserContext } from '@playwright/test';
+import http from 'http';
+import zlib from 'zlib';
+
+const HOP_BY_HOP = new Set([
+  'content-encoding', 'transfer-encoding', 'connection', 'keep-alive',
+]);
+
+async function applyIIPatches(context: BrowserContext, seed: number): Promise<void> {
+  await context.addInitScript(() => {
+    try {
+      if (typeof PublicKeyCredential !== 'undefined') {
+        Object.defineProperty(
+          PublicKeyCredential,
+          'isUserVerifyingPlatformAuthenticatorAvailable',
+          { value: () => Promise.resolve(true), writable: true, configurable: true }
+        );
+      }
+    } catch (_) {}
+    try {
+      navigator.credentials.get = function () {
+        return Promise.reject(new DOMException('No credentials available', 'NotAllowedError'));
+      };
+    } catch (_) {}
+  });
+
+  await context.route(
+    (url) => url.hostname !== 'localhost' && url.hostname.endsWith('.localhost'),
+    (route) => {
+      const url = new URL(route.request().url());
+      const req = http.request(
+        {
+          hostname: '127.0.0.1',
+          port: parseInt(url.port) || 80,
+          path: url.pathname + url.search,
+          method: route.request().method(),
+          headers: { ...route.request().headers(), host: url.host },
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (c: Buffer) => chunks.push(c));
+          res.on('end', () => {
+            const rawBody = Buffer.concat(chunks);
+            const encoding = (res.headers['content-encoding'] ?? '').toLowerCase();
+
+            const headers: Record<string, string> = {};
+            for (const [k, v] of Object.entries(res.headers)) {
+              if (!HOP_BY_HOP.has(k) && v !== undefined) {
+                headers[k] = Array.isArray(v) ? v.join('\n') : String(v);
+              }
+            }
+
+            let body: Buffer;
+            try {
+              if (encoding === 'gzip' || encoding === 'x-gzip') body = zlib.gunzipSync(rawBody);
+              else if (encoding === 'br') body = zlib.brotliDecompressSync(rawBody);
+              else if (encoding === 'deflate') body = zlib.inflateSync(rawBody);
+              else body = rawBody;
+            } catch (_) {
+              body = rawBody;
+            }
+
+            const p = url.pathname;
+            if (p.includes('/_app/immutable/entry/start') && p.endsWith('.js')) {
+              let src = body.toString('utf8');
+              src = src.replaceAll('Vr.dummy_auth[0]?.[0]!==void 0?', 'true?');
+              src = src.replace('return BigInt(0)}', `return BigInt(${seed})}`);
+              body = Buffer.from(src, 'utf8');
+            }
+
+            route
+              .fulfill({ status: res.statusCode ?? 200, headers, body })
+              .catch(() => {});
+          });
+        }
+      );
+      req.on('error', () => route.abort());
+      const postBody = route.request().postDataBuffer();
+      if (postBody) req.write(postBody);
+      req.end();
+    }
+  );
+}
+
+export const test = base.extend<object>({
+  context: async ({ context }, use) => {
+    const seed = Math.floor(Math.random() * 2 ** 32);
+    await applyIIPatches(context, seed);
+    await use(context);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/icp-dapp-launcher/install-dapp.spec.ts
+++ b/tests/icp-dapp-launcher/install-dapp.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures.js';
 import {
   icpDappLauncherUrl,
   loadTestEnv,

--- a/tests/icp-dapp-launcher/install-demo.spec.ts
+++ b/tests/icp-dapp-launcher/install-demo.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../fixtures.js';
 import {
   icpDappLauncherUrl,
   loadTestEnv,

--- a/tests/ii-helpers.ts
+++ b/tests/ii-helpers.ts
@@ -3,12 +3,19 @@ import type { Page } from '@playwright/test';
 /**
  * Handle the II v2 popup authentication flow.
  *
- * Supports three scenarios:
- * - Existing canister: "Continue with passkey" → "Use existing identity" → "Continue"
- * - Fresh canister (no identity yet): above path errors → "Create new identity" fallback
- * - Returning session (same browser context): "Continue" directly
+ * icp-cli's bundled II uses DUMMY_AUTH — no real WebAuthn is needed. The fixture
+ * in fixtures.ts patches the II JS bundle to force the DUMMY_AUTH path and sets
+ * a unique random seed per test context to avoid credential conflicts between tests.
+ *
+ * Scenarios:
+ *  - First popup (no stored identity): CWP → "Create new identity" → name form → done
+ *  - Returning popup (same context): "Continue" appears directly (II session persists)
  */
 export async function handleIIPopup(popup: Page): Promise<void> {
+  await popup
+    .waitForURL((url) => !url.href.startsWith('about:'), { timeout: 25000 })
+    .catch(() => {});
+
   await popup.waitForLoadState('domcontentloaded');
 
   const continueWithPasskey = popup.getByRole('button', {
@@ -20,51 +27,27 @@ export async function handleIIPopup(popup: Page): Promise<void> {
     exact: true,
   });
 
-  // Wait for either button to appear
   await Promise.race([
-    continueWithPasskey.waitFor({ state: 'visible', timeout: 15000 }),
-    continueBtn.waitFor({ state: 'visible', timeout: 15000 }),
+    continueWithPasskey.waitFor({ state: 'visible', timeout: 30000 }),
+    continueBtn.waitFor({ state: 'visible', timeout: 30000 }),
   ]);
 
   if (await continueWithPasskey.isVisible()) {
     await continueWithPasskey.click();
 
-    // Try "Use existing identity" (works when canister already has a dummy identity)
-    const useExistingBtn = popup.getByRole('button', {
-      name: 'Use existing identity',
+    const createNewBtn = popup.getByRole('button', {
+      name: 'Create new identity',
       exact: true,
     });
-    await useExistingBtn.waitFor({ state: 'visible', timeout: 10000 });
-    await useExistingBtn.click();
+    await createNewBtn.waitFor({ state: 'visible', timeout: 20000 });
+    await createNewBtn.click();
 
-    // Check if existing identity was found (Continue appears) or not (error appears)
-    const errorText = popup.getByText(
-      'Cannot read properties of undefined'
-    );
-    const hasError = await errorText
-      .waitFor({ state: 'visible', timeout: 3000 })
-      .then(() => true)
-      .catch(() => false);
+    const nameInput = popup.locator('input[placeholder="Identity name"]');
+    await nameInput.waitFor({ state: 'visible', timeout: 15000 });
+    await nameInput.fill('Test');
+    await popup.getByRole('button', { name: 'Create identity', exact: true }).click();
 
-    if (hasError) {
-      // Fresh canister — no identity exists yet, create one
-      const createNewBtn = popup.getByRole('button', {
-        name: 'Create new identity',
-        exact: true,
-      });
-      await createNewBtn.waitFor({ state: 'visible', timeout: 10000 });
-      await createNewBtn.click();
-
-      const nameInput = popup.locator('input[placeholder="Identity name"]');
-      await nameInput.waitFor({ state: 'visible', timeout: 10000 });
-      await nameInput.fill('Test');
-      await popup
-        .getByRole('button', { name: 'Create identity', exact: true })
-        .click();
-    }
-
-    // Wait for the authorization "Continue" button
-    await continueBtn.waitFor({ state: 'visible', timeout: 15000 });
+    await continueBtn.waitFor({ state: 'visible', timeout: 30000 });
   }
 
   await continueBtn.click();

--- a/tests/my-hello-world-frontend/hello-world.spec.ts
+++ b/tests/my-hello-world-frontend/hello-world.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../fixtures.js';
 import { installedHelloWorldExampleCanisterFrontendUrl, loadTestEnv } from '../helpers.js';
 import { handleIIPopup } from '../ii-helpers.js';
 


### PR DESCRIPTION
## Summary

- Patch the II JS entry bundle in the `*.localhost` proxy handler to force the DUMMY_AUTH path — icp-cli 0.2.1 sets `dummy_auth=opt null` which makes the runtime check evaluate `false`, causing real WebAuthn (`credentials.create()`) to run on headless Chrome
- Use a random seed per `derive-ii-principal` invocation to avoid credential conflicts when called multiple times against the same II canister
- Apply the same headless Chrome patches to all Playwright test contexts via `tests/fixtures.ts` (extended `test` fixture)
- Override `isUserVerifyingPlatformAuthenticatorAvailable → true` and reject empty `credentials.get()` with `NotAllowedError` to unblock II UI rendering on headless Linux
- Proxy `localhost:8080` requests via Node.js HTTP to bypass CORS/IPv4-IPv6 ambiguity in Chrome

## Status

Work in progress — not all E2E tests passing yet.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)